### PR TITLE
[#51] 댓글 관련 API 마무리

### DIFF
--- a/src/main/java/com/example/demo/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/demo/domain/comment/controller/CommentController.java
@@ -17,41 +17,39 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/comments")
+@RequestMapping("/api/v1/comments")
 public class CommentController {
     private final CommentService commentService;
 
     /**
      * 게시물 댓글 조회
-     * 요청 URL : /api/comments/{boardId}
-     * @param : boardId
-     * @return : 댓글 수, 댓글 관련내용(작성자, 대댓글 여부(그룹 아이디), 댓글 내용, 좋아요, 수정 날짜)
+     * 요청 URL : /api/v1/comments/{boardId}
+     * @param :
+     * @return : 댓글 전체 수, 각 댓글 관련 정보(댓글 아이디, 작성자 닉네임, 대댓글 여부(그룹 아이디), 댓글 내용, 대댓글 리스트)
      */
     @GetMapping("/{boardId}")
-    public ResponseEntity<ResponseBody<CommentResponse>> getBoardComments(@PathVariable Long boardId) {
+    public ResponseEntity<ResponseBody<CommentResponse>> getComments(@PathVariable Long boardId) {
         return ResponseEntity.ok(createSuccessResponse(commentService.findByBoardId(boardId)));
     }
 
     /**
      * 댓글 저장
-     * 요청 URL : /api/comments/{boardId}
-     * @param : user, commentRequest(content, groupId, depth), boardId
-     * @return : commentId, content, username, createdAt, parentId
+     * 요청 URL : /api/v1/comments/{boardId}
+     * @param : 작성 댓글 정보(내용, 대댓글 여부(그룹 아이디))
+     * @return : 작성 댓글 관련 정보(댓글 아이디, 대댓글 여부(그룹 아이디), 작성자 닉네임, 댓글 내용, 대댓글 리스트)
      */
     @AssignUserId
     @PostMapping("/{boardId}")
-    public ResponseEntity<ResponseBody<CommentInfo>> createComment(Long userId,
-                                                     @RequestBody @Valid CommentRequest commentRequest,
-                                                     @PathVariable Long boardId) {
-
+    public ResponseEntity<ResponseBody<CommentInfo>> createComment(Long userId, @RequestBody @Valid CommentRequest commentRequest, @PathVariable Long boardId) {
+        // 댓글 작성시 사용자 권한 확인
         return ResponseEntity.ok(createSuccessResponse(commentService.save(userId, commentRequest, boardId)));
     }
 
     /**
      * 댓글 수정
-     * 요청 URL : /api/comments/{commentId}
-     * @param : user, commentRequest()
-     * @return : commentId, content, username, updatedAt, parentId
+     * 요청 URL : /api/v1/comments/{commentId}
+     * @param : 작성 댓글 정보(내용, 대댓글 여부(그룹 아이디))
+     * @return : 수정 댓글 관련 정보(댓글 아이디, 대댓글 여부(그룹 아이디), 작성자 닉네임, 댓글 내용, 대댓글 리스트)
      */
     @AssignUserId
     @PatchMapping("/{commentId}")
@@ -63,24 +61,17 @@ public class CommentController {
 
     /**
      * 댓글 삭제(부모 댓글 삭제 시 삭제가 아닌 닉네임, 내용 교체만)
-     * 요청 URL : /api/comments/{commentId}
-     * @param : commentId
+     * 요청 URL : /api/v1/comments/{commentId}
+     * @param :
      * @return : 응답코드
      */
+    @AssignUserId
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ResponseBody<Void>> deleteComment(@PathVariable Long commentId) {
-        commentService.delete(commentId);
+    public ResponseEntity<ResponseBody<Void>> deleteComment(Long userId, @PathVariable Long commentId) {
+        commentService.delete(commentId, userId);
         return ResponseEntity.ok().body(createSuccessResponse());
     }
 
-    // 게시물 댓글 수 조회
-
-    // 사용자가 작성한 댓글 조회
-
-    // 대댓글 작성
-
-    // 댓글 좋아요
-
-    // 댓글 좋아요 삭제
+    // 사용자 댓글 조회?
 
 }

--- a/src/main/java/com/example/demo/domain/comment/controller/FakeLoginController.java
+++ b/src/main/java/com/example/demo/domain/comment/controller/FakeLoginController.java
@@ -1,0 +1,35 @@
+package com.example.demo.domain.comment.controller;
+
+import com.example.demo.domain.auth.dto.request.LoginRequest;
+import com.example.demo.domain.auth.dto.response.LoginResponse;
+import com.example.demo.domain.user.domain.vo.Role;
+import com.example.demo.global.base.dto.ResponseBody;
+import com.example.demo.global.jwt.JwtHandler;
+import com.example.demo.global.jwt.JwtUserClaim;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.demo.global.base.dto.ResponseUtil.createSuccessResponse;
+
+@RestController
+@RequestMapping("/api/test/auth/login")
+@RequiredArgsConstructor
+public class FakeLoginController {
+    private final JwtHandler jwtHandler;
+    @PostMapping
+    public ResponseEntity<ResponseBody<LoginResponse>> fakeLogin() {
+        JwtUserClaim claim = new JwtUserClaim(1L, Role.ROLE_USER);
+        String token = jwtHandler.createToken(claim);
+        LoginResponse response = new LoginResponse(token);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(createSuccessResponse(response));
+    }
+}

--- a/src/main/java/com/example/demo/domain/comment/domain/entity/Comment.java
+++ b/src/main/java/com/example/demo/domain/comment/domain/entity/Comment.java
@@ -47,12 +47,6 @@ public class Comment extends BaseEntity {
     @OrderBy("createdAt ASC")
     private List<Comment> replyComments = new ArrayList<>();
 
-    @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "comment_like",
-            joinColumns = @JoinColumn(name = "comment_id"),
-            inverseJoinColumns = @JoinColumn(name = "user_id"))
-    private Set<User> likedUsers = new HashSet<>();
-
     @Builder
     public Comment(String content, Board board, User user, Comment parentComment) {
         this.content = content;

--- a/src/main/java/com/example/demo/domain/comment/domain/request/CommentRequest.java
+++ b/src/main/java/com/example/demo/domain/comment/domain/request/CommentRequest.java
@@ -2,6 +2,7 @@ package com.example.demo.domain.comment.domain.request;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,7 +10,7 @@ import lombok.Setter;
 @Setter
 public class CommentRequest {
     @NotBlank(message = "내용은 필수 항목입니다.")
-    @Max(value = 500,message = "최대 제한 500글자 입니다.")
+    @Size(min = 1, max = 500,message = "최대 제한 500글자 입니다.")
     private String contents;
 
     private Long groupId;

--- a/src/main/java/com/example/demo/domain/comment/domain/response/CommentInfo.java
+++ b/src/main/java/com/example/demo/domain/comment/domain/response/CommentInfo.java
@@ -17,7 +17,6 @@ public class CommentInfo {
     private Long groupId;
     private String userNickname;
     private String contents;
-    private int likedCount;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
@@ -27,11 +26,10 @@ public class CommentInfo {
     private List<CommentInfo> replyComments;
 
     protected CommentInfo(Long commentId, String userNickname, String contents,
-                       int likedCount, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+                          LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         this.commentId = commentId;
         this.userNickname = userNickname;
         this.contents = contents;
-        this.likedCount = likedCount;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.deletedAt = deletedAt;
@@ -41,7 +39,6 @@ public class CommentInfo {
         CommentInfo commentInfo = new CommentInfo(comment.getId(),
                 comment.getUser().getNickname(),
                 comment.getContent(),
-                comment.getLikedUsers().size(),
                 comment.getCreatedAt(),
                 comment.getUpdatedAt(),
                 comment.getDeletedAt()

--- a/src/main/java/com/example/demo/domain/comment/domain/response/CommentResponse.java
+++ b/src/main/java/com/example/demo/domain/comment/domain/response/CommentResponse.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.comment.domain.response;
 
+import com.example.demo.domain.comment.domain.entity.Comment;
 import lombok.*;
 
 import java.util.List;
@@ -12,6 +13,10 @@ public class CommentResponse {
     private List<CommentInfo> commentInfoList;
 
     public static CommentResponse from(List<CommentInfo> commentInfoList){
-        return new CommentResponse(commentInfoList.size(), commentInfoList);
+        int replyCommentsCount = 0;
+        for (CommentInfo commentInfo : commentInfoList){
+            replyCommentsCount += commentInfo.getReplyComments().size();
+        }
+        return new CommentResponse(replyCommentsCount+commentInfoList.size(), commentInfoList);
     }
 }

--- a/src/main/java/com/example/demo/domain/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/example/demo/domain/comment/repository/CustomCommentRepositoryImpl.java
@@ -20,7 +20,6 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository{
                 .join(comment.board, board).where(board.id.eq(boardId), comment.parentComment.isNull())
                 .join(comment.user, user).fetchJoin()
                 .leftJoin(comment.replyComments).fetchJoin()
-                .leftJoin(comment.likedUsers).fetchJoin()
                 .orderBy(comment.createdAt.asc())
                 .fetch();
     }

--- a/src/main/java/com/example/demo/global/aop/UserIdInjectionAspect.java
+++ b/src/main/java/com/example/demo/global/aop/UserIdInjectionAspect.java
@@ -12,6 +12,8 @@ import com.example.demo.global.jwt.JwtAuthentication;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
+
 @Slf4j
 @Aspect
 @Component
@@ -31,12 +33,13 @@ public class UserIdInjectionAspect {
 		}
 
 		Object[] args = joinPoint.getArgs();
-		for (int i = 0; i < args.length; i++) {
-			if (args[i] instanceof Long) {
-				args[i] = userId;
-				break;
-			}
-		}
+		args[0] = userId;
+//		for (int i = 0; i < args.length; i++) {
+//			if (args[i] instanceof Long) {
+//				args[i] = userId;
+//				break;
+//			}
+//		}
 
 		return joinPoint.proceed(args);
 	}

--- a/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests((authorizeRequests) -> authorizeRequests
 				.requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
                 .requestMatchers(HttpMethod.GET).permitAll()
+					.requestMatchers(HttpMethod.POST, "/api/test/**").permitAll()
 				.anyRequest().authenticated())
 
             .addFilterAfter(new JwtAuthenticationFilter(authenticationManager), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/example/demo/global/jwt/JwtHandler.java
+++ b/src/main/java/com/example/demo/global/jwt/JwtHandler.java
@@ -60,7 +60,7 @@ public class JwtHandler {
 	public JwtUserClaim convert(Claims claims) {
 		return new JwtUserClaim(
 			claims.get(USER_ID, Long.class),
-			claims.get(USER_ROLE, Role.class)
+			Role.valueOf(claims.get(USER_ROLE, String.class))
 		);
 	}
 }


### PR DESCRIPTION
### 🌱 작업 사항 
- 댓글 엔티티 수정 및 자잘한 수정
- response 할 게시물 댓글 수를 대댓글 포함하여 산정하도록 수정
- 댓글 수정 및 삭제 시 로그인 한 유저와 댓글 작성한 유저 일치여부 확인 추가
- 하드코딩 JWT 토큰 반환 임시 API 제작
- JWT 필터 인증/인가 테스트 시 에러났던 부분 수정
### ❓ 리뷰 포인트
- 저 담당부분은 아닌데 JWT 테스트 과정에서 오류가 났던 부분 해결해서 리팩토링을 진행했는데 의견 주시면 감사하겠습니다.
### 🦄 관련 이슈
resolves #51
