### PR TITLE
[#76] 뉴스레터, 세미나 신청 api 기능 개발

### DIFF
--- a/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
+++ b/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
@@ -1,7 +1,8 @@
 package com.example.demo.domain.newsletter.controller;
 
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
-import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateEmailRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateNotifyRequest;
 import com.example.demo.domain.newsletter.domain.dto.response.NewsletterInfo;
 import com.example.demo.domain.newsletter.service.NewsletterService;
 import com.example.demo.global.aop.AssignUserId;
@@ -39,10 +40,19 @@ public class NewsletterController {
 
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
-    @PatchMapping("/subscribe")
-    public ResponseEntity<ResponseBody<Void>> updateNewsletterInfo(Long userId,
-                                                                   @RequestBody @Valid NewsletterUpdateRequest request) {
-        newsletterService.updateNewsletterInfo(userId, request);
+    @PatchMapping("/subscribe/email")
+    public ResponseEntity<ResponseBody<Void>> updateNewsletterEmail(Long userId,
+                                                                    @RequestBody @Valid NewsletterUpdateEmailRequest request) {
+        newsletterService.updateNewsletterEmail(userId, request);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PatchMapping("/subscribe/notify")
+    public ResponseEntity<ResponseBody<Void>> updateNewsletterNotify(Long userId,
+                                                                   @RequestBody @Valid NewsletterUpdateNotifyRequest request) {
+        newsletterService.updateNewsletterNotify(userId, request);
         return ResponseEntity.ok(createSuccessResponse());
     }
 

--- a/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
+++ b/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
@@ -1,0 +1,38 @@
+package com.example.demo.domain.newsletter.controller;
+
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
+import com.example.demo.domain.newsletter.domain.dto.response.NewsletterInfo;
+import com.example.demo.domain.newsletter.service.NewsletterService;
+import com.example.demo.global.aop.AssignUserId;
+import com.example.demo.global.base.dto.ResponseBody;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.demo.global.base.dto.ResponseUtil.createSuccessResponse;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/newsletters")
+public class NewsletterController {
+
+    private final NewsletterService newsletterService;
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PostMapping("/subscribe")
+    public ResponseEntity<ResponseBody<Void>> subscribe(Long userId,
+                                                        @RequestBody @Valid NewsletterSubscribeRequest request) {
+        newsletterService.subscribe(userId, request);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @GetMapping ("/subscribe")
+    public ResponseEntity<ResponseBody<NewsletterInfo>> getNewsletterInfo(Long userId) {
+        return ResponseEntity.ok(createSuccessResponse(newsletterService.getNewsletterInfo(userId)));
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
+++ b/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.newsletter.controller;
 
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateRequest;
 import com.example.demo.domain.newsletter.domain.dto.response.NewsletterInfo;
 import com.example.demo.domain.newsletter.service.NewsletterService;
 import com.example.demo.global.aop.AssignUserId;
@@ -34,5 +35,22 @@ public class NewsletterController {
     @GetMapping ("/subscribe")
     public ResponseEntity<ResponseBody<NewsletterInfo>> getNewsletterInfo(Long userId) {
         return ResponseEntity.ok(createSuccessResponse(newsletterService.getNewsletterInfo(userId)));
+    }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PatchMapping("/subscribe")
+    public ResponseEntity<ResponseBody<Void>> updateNewsletterInfo(Long userId,
+                                                                   @RequestBody @Valid NewsletterUpdateRequest request) {
+        newsletterService.updateNewsletterInfo(userId, request);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @DeleteMapping("/subscribe")
+    public ResponseEntity<ResponseBody<Void>> deleteNewsletterInfo(Long userId) {
+        newsletterService.deleteNewsletterInfo(userId);
+        return ResponseEntity.ok(createSuccessResponse());
     }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
@@ -27,8 +27,6 @@ public class Newsletter extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
     @Column(nullable = false)
-    private Boolean isSeminarAnnouncementRequired;
-    @Column(nullable = false)
     private Boolean isSeminarContentUpdated;
     @Column(nullable = false)
     private Boolean isStudyUpdated;
@@ -38,7 +36,6 @@ public class Newsletter extends BaseEntity {
     @Builder
     public Newsletter(String email, Boolean isSeminarContentUpdated, Boolean isStudyUpdated, Boolean isProjectUpdated) {
         this.email = email;
-        this.isSeminarAnnouncementRequired = true; // 기획상 세미나 활동 공지에 대한 알림은 필수
         this.isSeminarContentUpdated = isSeminarContentUpdated;
         this.isStudyUpdated = isStudyUpdated;
         this.isProjectUpdated = isProjectUpdated;

--- a/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
@@ -1,9 +1,11 @@
 package com.example.demo.domain.newsletter.domain;
 
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateRequest;
 import com.example.demo.domain.user.domain.User;
 import com.example.demo.global.base.domain.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +24,7 @@ public class Newsletter extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
     @Column(nullable = false)
     private Boolean isSeminarAnnouncementRequired;
@@ -49,5 +51,12 @@ public class Newsletter extends BaseEntity {
                 .isStudyUpdated(request.isStudyUpdated())
                 .isProjectUpdated(request.isProjectUpdated())
                 .build();
+    }
+
+    public void updateNewsletterInfo(@Valid NewsletterUpdateRequest request) {
+        this.email = request.email();
+        this.isSeminarContentUpdated = request.isSeminarContentUpdated();
+        this.isStudyUpdated = request.isStudyUpdated();
+        this.isProjectUpdated = request.isProjectUpdated();
     }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
@@ -1,8 +1,8 @@
 package com.example.demo.domain.newsletter.domain;
 
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
-import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateRequest;
-import com.example.demo.domain.user.domain.User;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateEmailRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateNotifyRequest;
 import com.example.demo.global.base.domain.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.Valid;
@@ -50,8 +50,11 @@ public class Newsletter extends BaseEntity {
                 .build();
     }
 
-    public void updateNewsletterInfo(@Valid NewsletterUpdateRequest request) {
+    public void updateNewsletterEmail(@Valid NewsletterUpdateEmailRequest request) {
         this.email = request.email();
+    }
+
+    public void updateNewsletterNotify(@Valid NewsletterUpdateNotifyRequest request) {
         this.isSeminarContentUpdated = request.isSeminarContentUpdated();
         this.isStudyUpdated = request.isStudyUpdated();
         this.isProjectUpdated = request.isProjectUpdated();

--- a/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.newsletter.domain;
 
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
 import com.example.demo.domain.user.domain.User;
 import com.example.demo.global.base.domain.BaseEntity;
 import jakarta.persistence.*;
@@ -13,8 +14,8 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "news_letters")
-@SQLDelete(sql = "UPDATE news_letters SET deleted_at = NOW() where id=?")
+@Table(name = "newsletters")
+@SQLDelete(sql = "UPDATE newsletters SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 public class Newsletter extends BaseEntity {
 
@@ -32,17 +33,21 @@ public class Newsletter extends BaseEntity {
     @Column(nullable = false)
     private Boolean isProjectUpdated;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
-
     @Builder
-    public Newsletter(String email, Boolean isSeminarContentUpdated, Boolean isStudyUpdated, Boolean isProjectUpdated, User user) {
+    public Newsletter(String email, Boolean isSeminarContentUpdated, Boolean isStudyUpdated, Boolean isProjectUpdated) {
         this.email = email;
         this.isSeminarAnnouncementRequired = true; // 기획상 세미나 활동 공지에 대한 알림은 필수
         this.isSeminarContentUpdated = isSeminarContentUpdated;
         this.isStudyUpdated = isStudyUpdated;
         this.isProjectUpdated = isProjectUpdated;
-        this.user = user;
+    }
+
+    public static Newsletter from(NewsletterSubscribeRequest request) {
+        return Newsletter.builder()
+                .email(request.email())
+                .isSeminarContentUpdated(request.isSeminarContentUpdated())
+                .isStudyUpdated(request.isStudyUpdated())
+                .isProjectUpdated(request.isProjectUpdated())
+                .build();
     }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterSubscribeRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterSubscribeRequest.java
@@ -1,0 +1,14 @@
+package com.example.demo.domain.newsletter.domain.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
+
+public record NewsletterSubscribeRequest(
+        @Pattern(regexp = EMAIL_REGEXP)
+        String email,
+        Boolean isSeminarContentUpdated,
+        Boolean isStudyUpdated,
+        Boolean isProjectUpdated
+) {
+}

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateEmailRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateEmailRequest.java
@@ -4,11 +4,8 @@ import jakarta.validation.constraints.Pattern;
 
 import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
-public record NewsletterUpdateRequest(
+public record NewsletterUpdateEmailRequest(
         @Pattern(regexp = EMAIL_REGEXP)
-        String email,
-        Boolean isSeminarContentUpdated,
-        Boolean isStudyUpdated,
-        Boolean isProjectUpdated
+        String email
 ) {
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateNotifyRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateNotifyRequest.java
@@ -1,0 +1,12 @@
+package com.example.demo.domain.newsletter.domain.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
+
+public record NewsletterUpdateNotifyRequest(
+        Boolean isSeminarContentUpdated,
+        Boolean isStudyUpdated,
+        Boolean isProjectUpdated
+) {
+}

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.demo.domain.newsletter.domain.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
+
+public record NewsletterUpdateRequest(
+        @Pattern(regexp = EMAIL_REGEXP)
+        String email,
+        Boolean isSeminarContentUpdated,
+        Boolean isStudyUpdated,
+        Boolean isProjectUpdated
+) {
+}

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/response/NewsletterInfo.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/response/NewsletterInfo.java
@@ -1,0 +1,32 @@
+package com.example.demo.domain.newsletter.domain.dto.response;
+
+import com.example.demo.domain.newsletter.domain.Newsletter;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record NewsletterInfo(
+        Long id,
+        String email,
+        Boolean isSeminarAnnouncementRequired,
+        Boolean isSeminarContentUpdated,
+        Boolean isStudyUpdated,
+        Boolean isProjectUpdated,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime updatedAt
+) {
+    public static NewsletterInfo from(Newsletter newsletter) {
+        return new NewsletterInfo(
+                newsletter.getId(),
+                newsletter.getEmail(),
+                newsletter.getIsSeminarAnnouncementRequired(),
+                newsletter.getIsSeminarContentUpdated(),
+                newsletter.getIsStudyUpdated(),
+                newsletter.getIsProjectUpdated(),
+                newsletter.getCreatedAt(),
+                newsletter.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/response/NewsletterInfo.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/response/NewsletterInfo.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 public record NewsletterInfo(
         Long id,
         String email,
-        Boolean isSeminarAnnouncementRequired,
         Boolean isSeminarContentUpdated,
         Boolean isStudyUpdated,
         Boolean isProjectUpdated,
@@ -21,7 +20,6 @@ public record NewsletterInfo(
         return new NewsletterInfo(
                 newsletter.getId(),
                 newsletter.getEmail(),
-                newsletter.getIsSeminarAnnouncementRequired(),
                 newsletter.getIsSeminarContentUpdated(),
                 newsletter.getIsStudyUpdated(),
                 newsletter.getIsProjectUpdated(),

--- a/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.domain.newsletter.repository;
+
+import com.example.demo.domain.newsletter.domain.Newsletter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
@@ -1,7 +1,10 @@
 package com.example.demo.domain.newsletter.repository;
 
 import com.example.demo.domain.newsletter.domain.Newsletter;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
     boolean existsByEmail(String email);

--- a/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
@@ -2,6 +2,7 @@ package com.example.demo.domain.newsletter.service;
 
 import com.example.demo.domain.newsletter.domain.Newsletter;
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateRequest;
 import com.example.demo.domain.newsletter.domain.dto.response.NewsletterInfo;
 import com.example.demo.domain.newsletter.repository.NewsletterRepository;
 import com.example.demo.domain.user.domain.User;
@@ -42,5 +43,21 @@ public class NewsletterService {
             throw new ServiceException(SUBSCRIBE_NOT_FOUND);
         }
         return NewsletterInfo.from(user.getNewsletter());
+    }
+
+    @Transactional
+    public void updateNewsletterInfo(Long userId, @Valid NewsletterUpdateRequest request) {
+        User user = userService.validateUser(userId);
+        this.validateSubscribe(request.email());
+        user.getNewsletter().updateNewsletterInfo(request);
+    }
+
+    @Transactional
+    public void deleteNewsletterInfo(Long userId) {
+        User user = userService.validateUser(userId);
+        Newsletter newsletter = user.getNewsletter();
+        if (newsletter != null) {
+            user.mapNewsletter(null);
+        }
     }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
@@ -1,0 +1,46 @@
+package com.example.demo.domain.newsletter.service;
+
+import com.example.demo.domain.newsletter.domain.Newsletter;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
+import com.example.demo.domain.newsletter.domain.dto.response.NewsletterInfo;
+import com.example.demo.domain.newsletter.repository.NewsletterRepository;
+import com.example.demo.domain.user.domain.User;
+import com.example.demo.domain.user.service.UserService;
+import com.example.demo.global.base.exception.ServiceException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.demo.global.base.exception.ErrorCode.SUBSCRIBE_EMAIL_CONFLICT;
+import static com.example.demo.global.base.exception.ErrorCode.SUBSCRIBE_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class NewsletterService {
+
+    private final UserService userService;
+    private final NewsletterRepository newsletterRepository;
+
+    @Transactional
+    public void subscribe(Long userId, @Valid NewsletterSubscribeRequest request) {
+        User user = userService.validateUser(userId);
+        this.validateSubscribe(request.email());
+        user.mapNewsletter(Newsletter.from(request));
+    }
+    
+    public void validateSubscribe(String email) {
+        if (newsletterRepository.existsByEmail(email)) {
+            throw new ServiceException(SUBSCRIBE_EMAIL_CONFLICT);
+        }
+    }
+
+    public NewsletterInfo getNewsletterInfo(Long userId) {
+        User user = userService.validateUser(userId);
+        if (user.getNewsletter() == null) {
+            throw new ServiceException(SUBSCRIBE_NOT_FOUND);
+        }
+        return NewsletterInfo.from(user.getNewsletter());
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
@@ -2,7 +2,8 @@ package com.example.demo.domain.newsletter.service;
 
 import com.example.demo.domain.newsletter.domain.Newsletter;
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
-import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateEmailRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateNotifyRequest;
 import com.example.demo.domain.newsletter.domain.dto.response.NewsletterInfo;
 import com.example.demo.domain.newsletter.repository.NewsletterRepository;
 import com.example.demo.domain.user.domain.User;
@@ -46,10 +47,16 @@ public class NewsletterService {
     }
 
     @Transactional
-    public void updateNewsletterInfo(Long userId, @Valid NewsletterUpdateRequest request) {
+    public void updateNewsletterEmail(Long userId, @Valid NewsletterUpdateEmailRequest request) {
         User user = userService.validateUser(userId);
         this.validateSubscribe(request.email());
-        user.getNewsletter().updateNewsletterInfo(request);
+        user.getNewsletter().updateNewsletterEmail(request);
+    }
+
+    @Transactional
+    public void updateNewsletterNotify(Long userId, @Valid NewsletterUpdateNotifyRequest request) {
+        User user = userService.validateUser(userId);
+        user.getNewsletter().updateNewsletterNotify(request);
     }
 
     @Transactional

--- a/src/main/java/com/example/demo/domain/seminar_application/controller/SeminarApplicationController.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/controller/SeminarApplicationController.java
@@ -1,0 +1,61 @@
+package com.example.demo.domain.seminar_application.controller;
+
+import com.example.demo.domain.seminar_application.domain.dto.request.SeminarApplicationRequest;
+import com.example.demo.domain.seminar_application.domain.dto.request.SeminarApplicationUpdateRequest;
+import com.example.demo.domain.seminar_application.domain.dto.response.SeminarApplicationInfo;
+import com.example.demo.domain.seminar_application.service.SeminarApplicationService;
+import com.example.demo.global.aop.AssignUserId;
+import com.example.demo.global.base.dto.ResponseBody;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.demo.global.base.dto.ResponseUtil.createSuccessResponse;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/seminar-application")
+public class SeminarApplicationController {
+
+    private final SeminarApplicationService seminarApplicationService;
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PostMapping("/apply")
+    public ResponseEntity<ResponseBody<Void>> applyForSeminar(Long userId,
+                                                              @RequestBody @Valid SeminarApplicationRequest request) {
+        seminarApplicationService.applyForSeminar(userId, request);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @GetMapping("/apply")
+    public ResponseEntity<ResponseBody<Page<SeminarApplicationInfo>>> getSeminarApplicationByUserId(Long userId,
+                                                                                                    Pageable pageable) {
+        return ResponseEntity.ok(createSuccessResponse(seminarApplicationService.getSeminarApplicationByUserId(userId, pageable)));
+    }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PutMapping("/apply/{seminarApplicationId}")
+    public ResponseEntity<ResponseBody<Void>> updateSeminarApplication(Long userId,
+                                                                       @PathVariable Long seminarApplicationId,
+                                                                       @RequestBody @Valid SeminarApplicationUpdateRequest request) {
+        seminarApplicationService.updateSeminarApplication(userId, seminarApplicationId, request);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @DeleteMapping("/apply/{seminarApplicationId}")
+    public ResponseEntity<ResponseBody<Void>> deleteSeminarApplication(Long userId,
+                                                                       @PathVariable Long seminarApplicationId) {
+        seminarApplicationService.deleteSeminarApplication(userId, seminarApplicationId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+}

--- a/src/main/java/com/example/demo/domain/seminar_application/domain/SeminarApplication.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/domain/SeminarApplication.java
@@ -1,14 +1,19 @@
 package com.example.demo.domain.seminar_application.domain;
 
+import com.example.demo.domain.seminar_application.domain.dto.request.SeminarApplicationRequest;
+import com.example.demo.domain.seminar_application.domain.dto.request.SeminarApplicationUpdateRequest;
 import com.example.demo.domain.user.domain.User;
 import com.example.demo.global.base.domain.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,10 +32,9 @@ public class SeminarApplication extends BaseEntity {
     private int grade;
     private String studentId;
     private String phoneNumber;
-    private String preferredDate;
+    private LocalDate preferredDate;
     private String presentationTopic;
     private String seminarName;
-    private String topicDescription;
     private String estimatedDuration;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -38,7 +42,7 @@ public class SeminarApplication extends BaseEntity {
     private User user;
 
     @Builder
-    public SeminarApplication(String name, String department, int grade, String studentId, String phoneNumber, String preferredDate, String presentationTopic, String seminarName, String topicDescription, String estimatedDuration) {
+    public SeminarApplication(String name, String department, int grade, String studentId, String phoneNumber, LocalDate preferredDate, String presentationTopic, String seminarName, String estimatedDuration, User user) {
         this.name = name;
         this.department = department;
         this.grade = grade;
@@ -47,7 +51,40 @@ public class SeminarApplication extends BaseEntity {
         this.preferredDate = preferredDate;
         this.presentationTopic = presentationTopic;
         this.seminarName = seminarName;
-        this.topicDescription = topicDescription;
         this.estimatedDuration = estimatedDuration;
+        this.user = user;
+    }
+
+    public static SeminarApplication from(SeminarApplicationRequest request, User user) {
+        return SeminarApplication.builder()
+                .name(request.name())
+                .department(request.department())
+                .grade(request.grade())
+                .studentId(request.studentId())
+                .phoneNumber(request.phoneNumber())
+                .preferredDate(request.preferredDate())
+                .presentationTopic(request.presentationTopic())
+                .seminarName(request.seminarName())
+                .estimatedDuration(request.estimatedDuration())
+                .user(user)
+                .build();
+    }
+
+    public boolean canEditOrDelete() {
+        LocalDate currentDate = LocalDate.now();
+        LocalDate cutoffDate = preferredDate.minusDays(1); // 하루 전날
+        return currentDate.isBefore(cutoffDate) || currentDate.isEqual(cutoffDate);
+    }
+
+    public void updateSeminarApplicationInfo(@Valid SeminarApplicationUpdateRequest request) {
+        this.name = request.name();
+        this.department = request.department();
+        this.grade = request.grade();
+        this.studentId = request.studentId();
+        this.phoneNumber = request.phoneNumber();
+        this.preferredDate = request.preferredDate();
+        this.presentationTopic = request.presentationTopic();
+        this.seminarName = request.seminarName();
+        this.estimatedDuration = request.estimatedDuration();
     }
 }

--- a/src/main/java/com/example/demo/domain/seminar_application/domain/dto/request/SeminarApplicationRequest.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/domain/dto/request/SeminarApplicationRequest.java
@@ -1,0 +1,28 @@
+package com.example.demo.domain.seminar_application.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record SeminarApplicationRequest(
+        @NotBlank
+        String name,
+        @NotBlank
+        String department,
+        @NotNull
+        int grade,
+        @NotBlank
+        String studentId,
+        @NotBlank
+        String phoneNumber,
+        @NotNull
+        LocalDate preferredDate,
+        @NotBlank
+        String presentationTopic,
+        @NotBlank
+        String seminarName,
+        @NotBlank
+        String estimatedDuration
+) {
+}

--- a/src/main/java/com/example/demo/domain/seminar_application/domain/dto/request/SeminarApplicationUpdateRequest.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/domain/dto/request/SeminarApplicationUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.example.demo.domain.seminar_application.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record SeminarApplicationUpdateRequest(
+        @NotBlank
+        String name,
+        @NotBlank
+        String department,
+        @NotNull
+        int grade,
+        @NotBlank
+        String studentId,
+        @NotBlank
+        String phoneNumber,
+        @NotNull
+        LocalDate preferredDate,
+        @NotBlank
+        String presentationTopic,
+        @NotBlank
+        String seminarName,
+        @NotBlank
+        String estimatedDuration
+) {
+}

--- a/src/main/java/com/example/demo/domain/seminar_application/domain/dto/response/SeminarApplicationInfo.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/domain/dto/response/SeminarApplicationInfo.java
@@ -1,0 +1,42 @@
+package com.example.demo.domain.seminar_application.domain.dto.response;
+
+import com.example.demo.domain.seminar_application.domain.SeminarApplication;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record SeminarApplicationInfo(
+        Long id,
+        String name,
+        String department,
+        int grade,
+        String studentId,
+        String phoneNumber,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate preferredDate,
+        String presentationTopic,
+        String seminarName,
+        String estimatedDuration,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime updatedAt
+) {
+    public static SeminarApplicationInfo from(SeminarApplication application) {
+        return new SeminarApplicationInfo(
+                application.getId(),
+                application.getName(),
+                application.getDepartment(),
+                application.getGrade(),
+                application.getStudentId(),
+                application.getPhoneNumber(),
+                application.getPreferredDate(),
+                application.getPresentationTopic(),
+                application.getSeminarName(),
+                application.getEstimatedDuration(),
+                application.getCreatedAt(),
+                application.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/demo/domain/seminar_application/repository/SeminarApplicationRepository.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/repository/SeminarApplicationRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.domain.seminar_application.repository;
+
+import com.example.demo.domain.seminar_application.domain.SeminarApplication;
+import com.example.demo.domain.seminar_application.domain.dto.response.SeminarApplicationInfo;
+import com.example.demo.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeminarApplicationRepository extends JpaRepository<SeminarApplication, Long> {
+    Page<SeminarApplicationInfo> findByUser(User user, Pageable pageable);
+}

--- a/src/main/java/com/example/demo/domain/seminar_application/service/SeminarApplicationService.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/service/SeminarApplicationService.java
@@ -1,0 +1,73 @@
+package com.example.demo.domain.seminar_application.service;
+
+import com.example.demo.domain.seminar_application.domain.SeminarApplication;
+import com.example.demo.domain.seminar_application.domain.dto.request.SeminarApplicationRequest;
+import com.example.demo.domain.seminar_application.domain.dto.request.SeminarApplicationUpdateRequest;
+import com.example.demo.domain.seminar_application.domain.dto.response.SeminarApplicationInfo;
+import com.example.demo.domain.seminar_application.repository.SeminarApplicationRepository;
+import com.example.demo.domain.user.domain.User;
+import com.example.demo.domain.user.service.UserService;
+import com.example.demo.domain.user_addtional_info.service.UserAdditionalInfoService;
+import com.example.demo.global.base.exception.ServiceException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+import static com.example.demo.global.base.exception.ErrorCode.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class SeminarApplicationService {
+
+    private final UserService userService;
+    private final UserAdditionalInfoService userAdditionalInfoService;
+    private final SeminarApplicationRepository seminarApplicationRepository;
+
+    @Transactional
+    public void applyForSeminar(Long userId, @Valid SeminarApplicationRequest request) {
+        User user = userService.validateUser(userId);
+        userAdditionalInfoService.validateUserAdditionalInfo(user.getUserAdditionalInfo());
+        user.addSeminarApplications(SeminarApplication.from(request, user));
+    }
+
+    public Page<SeminarApplicationInfo> getSeminarApplicationByUserId(Long userId, Pageable pageable) {
+        User user = userService.validateUser(userId);
+        return seminarApplicationRepository.findByUser(user, pageable);
+    }
+
+    @Transactional
+    public void updateSeminarApplication(Long userId, Long seminarApplicationId, @Valid SeminarApplicationUpdateRequest request) {
+        SeminarApplication savedApplication = seminarApplicationRepository.findById(seminarApplicationId)
+                .orElseThrow(() -> new ServiceException(SEMINAR_APPLICATION_NOT_FOUND));
+        this.validateCanEditOrDelete(savedApplication);
+        this.validateIsApplicationOwner(userId, savedApplication.getUser().getId());
+        savedApplication.updateSeminarApplicationInfo(request);
+    }
+
+    public void validateCanEditOrDelete(SeminarApplication seminarApplication) {
+        if (!seminarApplication.canEditOrDelete()) {
+            throw new ServiceException(SEMINAR_APPLICATION_CANNOT_EDIT_OR_DELETE);
+        }
+    }
+
+    public void validateIsApplicationOwner(Long userId, Long applicationOwnerId) {
+        if (!Objects.equals(userId, applicationOwnerId)) {
+            throw new ServiceException(SEMINAR_APPLICATION_ACCESS_DENIED);
+        }
+    }
+
+    @Transactional
+    public void deleteSeminarApplication(Long userId, Long seminarApplicationId) {
+        SeminarApplication savedApplication = seminarApplicationRepository.findById(seminarApplicationId)
+                .orElseThrow(() -> new ServiceException(SEMINAR_APPLICATION_NOT_FOUND));
+        this.validateCanEditOrDelete(savedApplication);
+        this.validateIsApplicationOwner(userId, savedApplication.getUser().getId());
+        seminarApplicationRepository.delete(savedApplication);
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserController.java
@@ -1,4 +1,4 @@
-package com.example.demo.domain.user.api;
+package com.example.demo.domain.user.controller;
 
 
 import static com.example.demo.global.base.dto.ResponseUtil.*;

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -49,7 +49,7 @@ public class User extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private Role role;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "user_additional_info_id")
     private UserAdditionalInfo userAdditionalInfo;
 
@@ -66,7 +66,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.PERSIST)
     private List<Like> likes= new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SeminarApplication> seminarApplications = new ArrayList<>();
 
     @Builder
@@ -98,5 +98,9 @@ public class User extends BaseEntity {
 
     public void mapNewsletter(Newsletter newsletter) {
         this.newsletter = newsletter;
+    }
+
+    public void addSeminarApplications(SeminarApplication seminarApplication) {
+        this.seminarApplications.add(seminarApplication);
     }
 }

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -53,7 +53,7 @@ public class User extends BaseEntity {
     @JoinColumn(name = "user_additional_info_id")
     private UserAdditionalInfo userAdditionalInfo;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "news_letter_id")
     private Newsletter newsletter;
 

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -53,7 +53,8 @@ public class User extends BaseEntity {
     @JoinColumn(name = "user_additional_info_id")
     private UserAdditionalInfo userAdditionalInfo;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "user", cascade = CascadeType.PERSIST) // TODO. OneToOne 관계 추후 수정
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "news_letter_id")
     private Newsletter newsletter;
 
     @OneToMany(mappedBy = "user")
@@ -93,5 +94,9 @@ public class User extends BaseEntity {
 
     public void mapAdditionalInfo(UserAdditionalInfo userAdditionalInfo) {
         this.userAdditionalInfo = userAdditionalInfo;
+    }
+
+    public void mapNewsletter(Newsletter newsletter) {
+        this.newsletter = newsletter;
     }
 }

--- a/src/main/java/com/example/demo/domain/user_addtional_info/service/UserAdditionalInfoService.java
+++ b/src/main/java/com/example/demo/domain/user_addtional_info/service/UserAdditionalInfoService.java
@@ -23,10 +23,14 @@ public class UserAdditionalInfoService {
 
     public UserAdditionalInfoResponse getUserAdditionalInfo(Long userId) {
         User user = userService.validateUser(userId);
-        if (user.getUserAdditionalInfo() == null) {
+        this.validateUserAdditionalInfo(user.getUserAdditionalInfo());
+        return UserAdditionalInfoResponse.from(user.getUserAdditionalInfo());
+    }
+
+    public void validateUserAdditionalInfo(UserAdditionalInfo userAdditionalInfo) {
+        if (userAdditionalInfo == null) {
             throw new ServiceException(USER_ADDITIONAL_INFO_NOT_FOUND);
         }
-        return UserAdditionalInfoResponse.from(user.getUserAdditionalInfo());
     }
 
     @Transactional

--- a/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
@@ -54,6 +54,9 @@ public enum ErrorCode {
     PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_0001", "부모 댓글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_0002", "해당 id의 댓글을 찾을 수 없습니다."),
 
+    // Newsletter
+    SUBSCRIBE_EMAIL_CONFLICT(HttpStatus.CONFLICT, "NEWSLETTER_0001", "이미 구독되어있는 이메일입니다."),
+    SUBSCRIBE_NOT_FOUND(HttpStatus.NOT_FOUND, "NEWSLETTER_0002", "구독 정보가 존재하지 않습니다."),
     ;
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
@@ -57,6 +57,11 @@ public enum ErrorCode {
     // Newsletter
     SUBSCRIBE_EMAIL_CONFLICT(HttpStatus.CONFLICT, "NEWSLETTER_0001", "이미 구독되어있는 이메일입니다."),
     SUBSCRIBE_NOT_FOUND(HttpStatus.NOT_FOUND, "NEWSLETTER_0002", "구독 정보가 존재하지 않습니다."),
+
+    // SeminarApplication
+    SEMINAR_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "SEMINAR_0001", "해당 세미나 신청폼 정보가 존재하지 않습니다."),
+    SEMINAR_APPLICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "SEMINAR_0002", "해당 세미나 신청폼에 접근할 권한이 없습니다."),
+    SEMINAR_APPLICATION_CANNOT_EDIT_OR_DELETE(HttpStatus.FORBIDDEN, "SEMINAR_0003", "해당 세미나 신청폼을 수정/삭제할 수 있는 기간이 아닙니다."),
     ;
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                 .oauth2Login(configure -> configure
                         .authorizationEndpoint(config -> config
                             .authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
-                            .baseUri("/api/users/login/oauth2"))
+                            .baseUri("/api/users/oauth2"))
                         .userInfoEndpoint(config -> config.userService(customOAuth2UserService))
                         .successHandler(oAuth2AuthenticationSuccessHandler)
                         .failureHandler(oAuth2AuthenticationFailureHandler))

--- a/src/test/java/com/example/demo/base/ControllerTest.java
+++ b/src/test/java/com/example/demo/base/ControllerTest.java
@@ -1,6 +1,6 @@
 package com.example.demo.base;
 
-import com.example.demo.domain.user.api.UserController;
+import com.example.demo.domain.user.controller.UserController;
 import com.example.demo.domain.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 뉴스레터, 세미나 신청 api 기능 개발

### ❓ 리뷰 포인트
- 사용자 추가 정보가 입력되어야 사용할 수 있는 api에 대해서 `UserAdditionalInfoService.java` 에서 다음과 같은 메서드를 만들어 놨습니다.
  ```java
      public void validateUserAdditionalInfo(UserAdditionalInfo userAdditionalInfo) {
          if (userAdditionalInfo == null) {
              throw new ServiceException(USER_ADDITIONAL_INFO_NOT_FOUND);
          }
      }
  ```
  
  ```java
      @Transactional
      public void applyForSeminar(Long userId, @Valid SeminarApplicationRequest request) {
          User user = userService.validateUser(userId);
          userAdditionalInfoService.validateUserAdditionalInfo(user.getUserAdditionalInfo());
          user.addSeminarApplications(SeminarApplication.from(request, user));
      }
  ```
  이런식으로 해당 사용자의 추가 정보가 존재하는지 검사할 수 있습니다.

- 추가적으로 **회원 탈퇴가 되었을 때 사용자 추가 정보, 뉴스 레터, 세미나 신청 도메인에 대해서 cascade 하게 soft delete가 잘 동작하는 것을 확인했습니다!!**
- unique 필드가 걸린 필드도 deleted_at 으로 soft delete처리된 데이터에 대해서는 중복을 허용하는 듯 합니다. (신기)

- 물어보고 싶은 것
  ```java
      @Transactional
      public void subscribe(Long userId, @Valid NewsletterSubscribeRequest request) {
          User user = userService.validateUser(userId);
          this.validateSubscribe(request.email());
          user.mapNewsletter(Newsletter.from(request));
      }
  
      @Transactional
      public void deleteNewsletterInfo(Long userId) {
          User user = userService.validateUser(userId);
          Newsletter newsletter = user.getNewsletter();
          if (newsletter != null) {
              user.mapNewsletter(null);
          }
      }
  ```
  
  - 이런식으로 jpa의 `cascade = CascadeType.ALL, orphanRemoval = true` 을 활용해서 삽입/삭제 처리가 더 좋은 것 같나요? 아니면 `save`, 'delete` 처럼 직관적으로 repository를 사용한 방법이 더 좋아보이나요?

### 🦄 관련 이슈
resolves #76  <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
