### PR TITLE
[fix] 미반영 커밋 추가를 위한 pr

### DIFF
--- a/src/main/java/com/example/demo/domain/study_project_application/repository/StudyProjectApplicantRepository.java
+++ b/src/main/java/com/example/demo/domain/study_project_application/repository/StudyProjectApplicantRepository.java
@@ -1,7 +1,17 @@
 package com.example.demo.domain.study_project_application.repository;
 
 import com.example.demo.domain.study_project_application.domain.entity.StudyProjectApplicant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface StudyProjectApplicantRepository extends JpaRepository<StudyProjectApplicant, Long> {
+    Optional<List<StudyProjectApplicant>> findByStudyProjectBoard_Id(Long studyProjectBoard_id);
+
+    Optional<StudyProjectApplicant> findByUser_IdAndStudyProjectBoard_Id(Long userId, Long studyProjectBoardId);
+
+    Page<StudyProjectApplicant> findByStudyProjectBoard_IdOrderByCreatedAtDesc(Pageable pageable, Long studyProjectBoard_id);
 }

--- a/src/main/java/com/example/demo/domain/study_project_board/controller/StudyProjectBoardController.java
+++ b/src/main/java/com/example/demo/domain/study_project_board/controller/StudyProjectBoardController.java
@@ -108,6 +108,7 @@ public class StudyProjectBoardController {
      * @param : status[published, draft]
      */
     // 게시물 작성 전 임시저장 게시물을 불러온 후 저장하면 해당 API 요청
+    // TODO : 신청이 들어오면 수정못하도록
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @PatchMapping("/{studyProjectBoardId}")

--- a/src/main/java/com/example/demo/domain/study_project_board/domain/entity/StudyProjectBoard.java
+++ b/src/main/java/com/example/demo/domain/study_project_board/domain/entity/StudyProjectBoard.java
@@ -3,8 +3,6 @@ package com.example.demo.domain.study_project_board.domain.entity;
 import com.example.demo.domain.board.domain.dto.vo.Status;
 import com.example.demo.domain.comment.domain.entity.Comment;
 import com.example.demo.domain.study_project_application.domain.entity.StudyProjectApplicant;
-import com.example.demo.domain.study_project_application.domain.entity.StudyProjectApplicantAnswer;
-import com.example.demo.domain.study_project_application.repository.StudyProjectApplicantAnswerRepository;
 import com.example.demo.domain.study_project_board.domain.dto.request.StudyProjectBoardInfoAndFormRequest;
 import com.example.demo.domain.study_project_board.domain.dto.request.StudyProjectFormQuestionRequest;
 import com.example.demo.domain.study_project_board.domain.dto.vo.StudyProjectBoardTag;
@@ -135,8 +133,7 @@ public class StudyProjectBoard extends BaseEntity {
     public void updateFromRequest(StudyProjectBoardInfoAndFormRequest request,
                                   Status status,
                                   StudyProjectFormQuestionRepository studyProjectFormQuestionRepository,
-                                  StudyProjectFormChoiceAnswerRepository studyProjectFormChoiceAnswerRepository,
-                                  StudyProjectApplicantAnswerRepository studyProjectApplicantAnswerRepository) {
+                                  StudyProjectFormChoiceAnswerRepository studyProjectFormChoiceAnswerRepository) {
         // 게시물 업데이트
         this.title = request.getBoard().getTitle();
         this.summary = request.getBoard().getSummary();
@@ -177,9 +174,6 @@ public class StudyProjectBoard extends BaseEntity {
         while (questionIdx < size) {
             StudyProjectFormQuestion studyProjectFormQuestion = StudyProjectFormQuestion.from(request.getForm().get(questionIdx++), this);
             studyProjectFormQuestionList.add(studyProjectFormQuestion);
-            for (StudyProjectApplicant studyProjectApplicant : applicantList) {
-                studyProjectApplicantAnswerRepository.save(StudyProjectApplicantAnswer.newEmptyAnswerInstance(studyProjectFormQuestion, studyProjectApplicant));
-            }
         }
     }
 }

--- a/src/main/java/com/example/demo/domain/study_project_board/repository/QueryDslStudyProjectBoardRepository.java
+++ b/src/main/java/com/example/demo/domain/study_project_board/repository/QueryDslStudyProjectBoardRepository.java
@@ -17,5 +17,5 @@ public interface QueryDslStudyProjectBoardRepository {
 
     List<StudyProjectBoard> findDraftPageByUserIdByNoOffset(Long userId, int size, Long lastBoardId, boolean isFirst);
 
-    Optional<StudyProjectBoard> findByIdByFetchingChoiceAnswerListAndApplicant(Long ApplicationBoardId);
+    Optional<StudyProjectBoard> findByIdByFetchingChoiceAnswerList(Long ApplicationBoardId);
 }

--- a/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
@@ -10,15 +10,15 @@ public enum ErrorCode {
     // Common
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_0001", "잘못된 입력 값입니다."),
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "COMMON_0002", "잘못된 타입입니다."),
-    MISSING_INPUT_VALUE(HttpStatus.BAD_REQUEST,"COMMON_0003", "인자가 부족합니다."),
+    MISSING_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_0003", "인자가 부족합니다."),
     NOT_EXIST_API(HttpStatus.BAD_REQUEST, "COMMON_0004", "요청 주소가 올바르지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_0005", "사용할 수 없는 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_0006", "서버 에러입니다."),
     INVALID_JSON(HttpStatus.BAD_REQUEST, "COMMON_0007", "JSON 파싱 오류입니다."),
 
     // Security
-    NEED_AUTHORIZED(HttpStatus.UNAUTHORIZED, "SECURITY_0001","인증이 필요합니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "SECURITY_0002","권한이 없습니다."),
+    NEED_AUTHORIZED(HttpStatus.UNAUTHORIZED, "SECURITY_0001", "인증이 필요합니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "SECURITY_0002", "권한이 없습니다."),
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "SECURITY_0003", "JWT 토큰이 만료되었습니다."),
     JWT_INVALID(HttpStatus.UNAUTHORIZED, "SECURITY_0004", "JWT 토큰이 올바르지 않습니다."),
     JWT_NOT_EXIST(HttpStatus.UNAUTHORIZED, "SECURITY_0005", "JWT 토큰이 존재하지 않습니다."),
@@ -31,7 +31,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_0002", "비밀번호가 일치하지 않습니다."),
     USERID_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_0003", "존재하지 않는 아이디입니다."),
     EXIST_SAME_USERID(HttpStatus.CONFLICT, "AUTH_0004", "이미 사용중인 아이디 입니다."),
-    EXIST_SAME_NICKNAME(HttpStatus.CONFLICT, "AUTH_0005","이미 사용중인 닉네임 입니다."),
+    EXIST_SAME_NICKNAME(HttpStatus.CONFLICT, "AUTH_0005", "이미 사용중인 닉네임 입니다."),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_0001", "해당 사용자는 존재하지 않는 사용자입니다."),
@@ -40,10 +40,11 @@ public enum ErrorCode {
 
     // Board
     NOT_ACCESS_USER(HttpStatus.UNAUTHORIZED, "BOARD_0001", "해당 유저가 접근할 수 없는 게시물입니다."),
-    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_0002", "존재하지 않는 게시물입니다." ),
-    USER_ALREADY_LIKE_BOARD(HttpStatus.CONFLICT,"BOARD_0003", "이미 좋아요를 누른 게시물입니다."),
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_0002", "존재하지 않는 게시물입니다."),
+    USER_ALREADY_LIKE_BOARD(HttpStatus.CONFLICT, "BOARD_0003", "이미 좋아요를 누른 게시물입니다."),
     LIKE_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_0004", "좋아요는 인증을 해야합니다."),
     USER_NOT_LIKE_BOARD(HttpStatus.NOT_FOUND, "BOARD_0005", "좋아요를 누르지 않은 게시물입니다."),
+    DEADLINE_EXPIRED(HttpStatus.FORBIDDEN, "BOARD_0006", "신청 마감된 게시물입니다."),
 
     // FILE
     FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "FILE_0001", "파일의 용량이 너무 큽니다."),
@@ -62,7 +63,16 @@ public enum ErrorCode {
     SEMINAR_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "SEMINAR_0001", "해당 세미나 신청폼 정보가 존재하지 않습니다."),
     SEMINAR_APPLICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "SEMINAR_0002", "해당 세미나 신청폼에 접근할 권한이 없습니다."),
     SEMINAR_APPLICATION_CANNOT_EDIT_OR_DELETE(HttpStatus.FORBIDDEN, "SEMINAR_0003", "해당 세미나 신청폼을 수정/삭제할 수 있는 기간이 아닙니다."),
-    ;
+
+    // StudyProjectBoard
+    STUDYPROJECT_APPLICATION_EXIST(HttpStatus.BAD_REQUEST, "STUDYPROEJCT_0001", "게시물에 신청한 사람이 존재합니다."),
+
+    // StudyProjectFormQuestion
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_0001", "질문 정보가 존재하지 않습니다."),
+
+    // StudyProjectApplicant
+    STUDYPROJECT_APPLICANT_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICANT_0001", "신청자 정보가 존재하지 않습니다."),
+    STUDYPROJECT_APPLICANT_EXIST(HttpStatus.CONFLICT, "APPLICANT_0002", "이미 신청한 사용자입니다.");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/example/demo/global/utils/QueryDslUtils.java
+++ b/src/main/java/com/example/demo/global/utils/QueryDslUtils.java
@@ -1,0 +1,14 @@
+package com.example.demo.global.utils;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+
+public class QueryDslUtils {
+    // QueryDsl로 Pageable sort를 하기 위한 메서드
+    public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName) {
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+        return new OrderSpecifier(order, fieldPath);
+    }
+}


### PR DESCRIPTION
### 🌱 작업 사항 
- 미반영 커밋을 추가하기 위해 불가피하게 연관된 추가 기능도 같이 올려야 하는 점 죄송합니다...
- 기획과 이야기한 결과 study, project 게시물에 신청자가 한 명이라도 생기면 게시물 수정을 못하게 변경하였습니다.
- QueryDsl에서 Pageable 객체에 있는 sort를 사용하기 위한 클래스를 추가하였습니다.
QueryDsl를 사용하는 클래스에서 order.getProperty()(ex. createdAt)에 따라 OrderSpecifier<?> 객체를 QueryDslUtils.getSortedColumn에서 가져오도록 메소드를 만들어 준 후, orderBy절에서 다음과 같이 사용하시면 됩니다.

<QueryDslUtils>


![image](https://github.com/user-attachments/assets/99a99fc6-32a8-431e-a993-e4a9d5dc1bc5)

<QueryDsl를 사용하는 클래스에서 QueryDslUtils 호출하는 메서드>

![image](https://github.com/user-attachments/assets/fd516cdc-b4c6-4a8f-9a30-8029aeb3049d)

<orderBy 적용>

![image](https://github.com/user-attachments/assets/ce3b07fd-1e53-4193-9210-3dd748db684a)

### ❓ 리뷰 포인트
- 크게 리뷰 할 것은 없어보이는데 시간되시면 게시물 수정 서비스 로직만 읽어보시면 됩니다

### 🦄 관련 이슈
