### PR TITLE
[#83] 계층 권한을 설정하고, 그에 따른 자잘한 변경

### DIFF
--- a/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
+++ b/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
@@ -23,7 +23,7 @@ public class NewsletterController {
     private final NewsletterService newsletterService;
 
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PostMapping("/subscribe")
     public ResponseEntity<ResponseBody<Void>> subscribe(Long userId,
                                                         @RequestBody @Valid NewsletterSubscribeRequest request) {
@@ -32,14 +32,14 @@ public class NewsletterController {
     }
 
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @GetMapping ("/subscribe")
     public ResponseEntity<ResponseBody<NewsletterInfo>> getNewsletterInfo(Long userId) {
         return ResponseEntity.ok(createSuccessResponse(newsletterService.getNewsletterInfo(userId)));
     }
 
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PatchMapping("/subscribe/email")
     public ResponseEntity<ResponseBody<Void>> updateNewsletterEmail(Long userId,
                                                                     @RequestBody @Valid NewsletterUpdateEmailRequest request) {
@@ -48,7 +48,7 @@ public class NewsletterController {
     }
 
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PatchMapping("/subscribe/notify")
     public ResponseEntity<ResponseBody<Void>> updateNewsletterNotify(Long userId,
                                                                    @RequestBody @Valid NewsletterUpdateNotifyRequest request) {
@@ -57,7 +57,7 @@ public class NewsletterController {
     }
 
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @DeleteMapping("/subscribe")
     public ResponseEntity<ResponseBody<Void>> deleteNewsletterInfo(Long userId) {
         newsletterService.deleteNewsletterInfo(userId);

--- a/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
+++ b/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
@@ -17,7 +17,7 @@ import static com.example.demo.global.base.dto.ResponseUtil.createSuccessRespons
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/newsletters")
+@RequestMapping("/api/v1/newsletters")
 public class NewsletterController {
 
     private final NewsletterService newsletterService;

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterSubscribeRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterSubscribeRequest.java
@@ -1,14 +1,14 @@
 package com.example.demo.domain.newsletter.domain.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
 public record NewsletterSubscribeRequest(
-        @Pattern(regexp = EMAIL_REGEXP)
-        String email,
-        Boolean isSeminarContentUpdated,
-        Boolean isStudyUpdated,
-        Boolean isProjectUpdated
+        @Pattern(regexp = EMAIL_REGEXP, message = "이메일 정규식을 맞춰주세요.") String email,
+        @NotNull(message = "세미나 내용정리 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isSeminarContentUpdated,
+        @NotNull(message = "스터디 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isStudyUpdated,
+        @NotNull(message = "프로젝트 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isProjectUpdated
 ) {
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateEmailRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateEmailRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Pattern;
 import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
 public record NewsletterUpdateEmailRequest(
-        @Pattern(regexp = EMAIL_REGEXP)
-        String email
+        @Pattern(regexp = EMAIL_REGEXP, message = "이메일 정규식을 맞춰주세요.") String email
 ) {
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateNotifyRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateNotifyRequest.java
@@ -1,12 +1,13 @@
 package com.example.demo.domain.newsletter.domain.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
 public record NewsletterUpdateNotifyRequest(
-        Boolean isSeminarContentUpdated,
-        Boolean isStudyUpdated,
-        Boolean isProjectUpdated
+        @NotNull(message = "세미나 내용정리 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isSeminarContentUpdated,
+        @NotNull(message = "스터디 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isStudyUpdated,
+        @NotNull(message = "프로젝트 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isProjectUpdated
 ) {
 }

--- a/src/main/java/com/example/demo/domain/seminar_application/controller/SeminarApplicationController.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/controller/SeminarApplicationController.java
@@ -18,7 +18,7 @@ import static com.example.demo.global.base.dto.ResponseUtil.createSuccessRespons
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/seminar-application")
+@RequestMapping("/api/v1/seminar-application")
 public class SeminarApplicationController {
 
     private final SeminarApplicationService seminarApplicationService;

--- a/src/main/java/com/example/demo/domain/seminar_application/controller/SeminarApplicationController.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/controller/SeminarApplicationController.java
@@ -18,30 +18,39 @@ import static com.example.demo.global.base.dto.ResponseUtil.createSuccessRespons
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/seminar-application")
+@RequestMapping("/api/v1/seminar-applications")
 public class SeminarApplicationController {
 
     private final SeminarApplicationService seminarApplicationService;
 
+    /**
+     * 세미나 신청서 작성
+     */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
-    @PostMapping("/apply")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_ACTIVE_USER')")
+    @PostMapping
     public ResponseEntity<ResponseBody<Void>> applyForSeminar(Long userId,
                                                               @RequestBody @Valid SeminarApplicationRequest request) {
         seminarApplicationService.applyForSeminar(userId, request);
         return ResponseEntity.ok(createSuccessResponse());
     }
 
+    /**
+     * 내가 쓴 모든 세미나 신청서 목록 조회
+     */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
-    @GetMapping("/apply")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_ACTIVE_USER')")
+    @GetMapping
     public ResponseEntity<ResponseBody<Page<SeminarApplicationInfo>>> getSeminarApplicationByUserId(Long userId,
                                                                                                     Pageable pageable) {
         return ResponseEntity.ok(createSuccessResponse(seminarApplicationService.getSeminarApplicationByUserId(userId, pageable)));
     }
 
+    /**
+     * 내가 쓴 신청서 내용 수정
+     */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_ACTIVE_USER')")
     @PutMapping("/apply/{seminarApplicationId}")
     public ResponseEntity<ResponseBody<Void>> updateSeminarApplication(Long userId,
                                                                        @PathVariable Long seminarApplicationId,
@@ -50,8 +59,11 @@ public class SeminarApplicationController {
         return ResponseEntity.ok(createSuccessResponse());
     }
 
+    /**
+     * 내가 쓴 신청서 삭제
+     */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_ACTIVE_USER')")
     @DeleteMapping("/apply/{seminarApplicationId}")
     public ResponseEntity<ResponseBody<Void>> deleteSeminarApplication(Long userId,
                                                                        @PathVariable Long seminarApplicationId) {

--- a/src/main/java/com/example/demo/domain/seminar_application/controller/SeminarApplicationController.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/controller/SeminarApplicationController.java
@@ -4,6 +4,7 @@ import com.example.demo.domain.seminar_application.domain.dto.request.SeminarApp
 import com.example.demo.domain.seminar_application.domain.dto.request.SeminarApplicationUpdateRequest;
 import com.example.demo.domain.seminar_application.domain.dto.response.SeminarApplicationInfo;
 import com.example.demo.domain.seminar_application.service.SeminarApplicationService;
+import com.example.demo.domain.token.domain.dto.TokenResponse;
 import com.example.demo.global.aop.AssignUserId;
 import com.example.demo.global.base.dto.ResponseBody;
 import jakarta.validation.Valid;
@@ -29,10 +30,11 @@ public class SeminarApplicationController {
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ACTIVE_USER')")
     @PostMapping
-    public ResponseEntity<ResponseBody<Void>> applyForSeminar(Long userId,
-                                                              @RequestBody @Valid SeminarApplicationRequest request) {
-        seminarApplicationService.applyForSeminar(userId, request);
-        return ResponseEntity.ok(createSuccessResponse());
+    public ResponseEntity<ResponseBody<TokenResponse>> applyForSeminar(Long userId,
+                                                                       @RequestBody @Valid SeminarApplicationRequest request) {
+        return seminarApplicationService.applyForSeminar(userId, request)
+                .map(token -> ResponseEntity.ok(createSuccessResponse(token))) // 200 OK
+                .orElseGet(() -> ResponseEntity.noContent().build()); // 204 No Content
     }
 
     /**
@@ -51,7 +53,7 @@ public class SeminarApplicationController {
      */
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ACTIVE_USER')")
-    @PutMapping("/apply/{seminarApplicationId}")
+    @PutMapping("/{seminarApplicationId}")
     public ResponseEntity<ResponseBody<Void>> updateSeminarApplication(Long userId,
                                                                        @PathVariable Long seminarApplicationId,
                                                                        @RequestBody @Valid SeminarApplicationUpdateRequest request) {
@@ -64,7 +66,7 @@ public class SeminarApplicationController {
      */
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ACTIVE_USER')")
-    @DeleteMapping("/apply/{seminarApplicationId}")
+    @DeleteMapping("/{seminarApplicationId}")
     public ResponseEntity<ResponseBody<Void>> deleteSeminarApplication(Long userId,
                                                                        @PathVariable Long seminarApplicationId) {
         seminarApplicationService.deleteSeminarApplication(userId, seminarApplicationId);

--- a/src/main/java/com/example/demo/domain/seminar_application/domain/SeminarApplication.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/domain/SeminarApplication.java
@@ -72,7 +72,7 @@ public class SeminarApplication extends BaseEntity {
 
     public boolean canEditOrDelete() {
         LocalDate currentDate = LocalDate.now();
-        LocalDate cutoffDate = preferredDate.minusDays(1); // 하루 전날
+        LocalDate cutoffDate = preferredDate.minusDays(2); // 2일전까지는 편집/삭제 가능
         return currentDate.isBefore(cutoffDate) || currentDate.isEqual(cutoffDate);
     }
 

--- a/src/main/java/com/example/demo/domain/seminar_application/domain/dto/request/SeminarApplicationRequest.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/domain/dto/request/SeminarApplicationRequest.java
@@ -6,23 +6,14 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record SeminarApplicationRequest(
-        @NotBlank
-        String name,
-        @NotBlank
-        String department,
-        @NotNull
-        int grade,
-        @NotBlank
-        String studentId,
-        @NotBlank
-        String phoneNumber,
-        @NotNull
-        LocalDate preferredDate,
-        @NotBlank
-        String presentationTopic,
-        @NotBlank
-        String seminarName,
-        @NotBlank
-        String estimatedDuration
+        @NotBlank(message = "이름은 빈값일 수 없습니다.") String name,
+        @NotBlank(message = "학과는 빈값일 수 없습니다.") String department,
+        @NotNull(message = "학년은 빈값일 수 없습니다.") int grade,
+        @NotBlank(message = "학번은 빈값일 수 없습니다.") String studentId,
+        @NotBlank(message = "전화번호는 빈값일 수 없습니다.") String phoneNumber,
+        @NotNull(message = "희망 날짜는 빈값일 수 없습니다.") LocalDate preferredDate, // TODO. 날짜의 앞 뒤 한계 설정 필요?
+        @NotBlank(message = "발표 주제는 빈값일 수 없습니다.") String presentationTopic,
+        @NotBlank(message = "세미나 이름은 빈값일 수 없습니다.") String seminarName,
+        @NotBlank(message = "예상 시간은 빈값일 수 없습니다.") String estimatedDuration
 ) {
 }

--- a/src/main/java/com/example/demo/domain/seminar_application/domain/dto/request/SeminarApplicationUpdateRequest.java
+++ b/src/main/java/com/example/demo/domain/seminar_application/domain/dto/request/SeminarApplicationUpdateRequest.java
@@ -6,23 +6,14 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record SeminarApplicationUpdateRequest(
-        @NotBlank
-        String name,
-        @NotBlank
-        String department,
-        @NotNull
-        int grade,
-        @NotBlank
-        String studentId,
-        @NotBlank
-        String phoneNumber,
-        @NotNull
-        LocalDate preferredDate,
-        @NotBlank
-        String presentationTopic,
-        @NotBlank
-        String seminarName,
-        @NotBlank
-        String estimatedDuration
+        @NotBlank(message = "이름은 빈값일 수 없습니다.") String name,
+        @NotBlank(message = "학과는 빈값일 수 없습니다.") String department,
+        @NotNull(message = "학년은 빈값일 수 없습니다.") int grade,
+        @NotBlank(message = "학번은 빈값일 수 없습니다.") String studentId,
+        @NotBlank(message = "전화번호는 빈값일 수 없습니다.") String phoneNumber,
+        @NotNull(message = "희망 날짜는 빈값일 수 없습니다.") LocalDate preferredDate,
+        @NotBlank(message = "발표 주제는 빈값일 수 없습니다.") String presentationTopic,
+        @NotBlank(message = "세미나 이름은 빈값일 수 없습니다.") String seminarName,
+        @NotBlank(message = "예상 시간은 빈값일 수 없습니다.") String estimatedDuration
 ) {
 }

--- a/src/main/java/com/example/demo/domain/token/controller/TokenController.java
+++ b/src/main/java/com/example/demo/domain/token/controller/TokenController.java
@@ -16,7 +16,7 @@ import static com.example.demo.global.base.dto.ResponseUtil.createSuccessRespons
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/tokens")
+@RequestMapping("/api/v1/tokens")
 public class TokenController {
 
     private final TokenService tokenService;

--- a/src/main/java/com/example/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 public class UserController {
 
     private final UserService userService;

--- a/src/main/java/com/example/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
      * TODO. blacklist 고민
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @DeleteMapping("/logout")
     public ResponseEntity<ResponseBody<Void>> logout(Long userId) {
         userService.logout(userId);
@@ -65,7 +65,7 @@ public class UserController {
      * 사용자 닉네임 수정 api
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PatchMapping("/me/nickname")
     public ResponseEntity<ResponseBody<Void>> updateNickname(@RequestBody @Valid UpdateNicknameRequest request,
                                                                       Long userId) {
@@ -77,7 +77,7 @@ public class UserController {
      * 사용자 프로필 이미지 수정 api
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PatchMapping("/me/profileImage")
     public ResponseEntity<ResponseBody<Void>> updateProfileImage(@RequestBody @Valid UpdateProfileImageRequest request,
                                                                  Long userId) {
@@ -89,7 +89,7 @@ public class UserController {
      * 기본 사용자 정보 확인 api
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @GetMapping("/me")
     public ResponseEntity<ResponseBody<UserInfo>> getUserInfo(Long userId) {
         return ResponseEntity.ok(createSuccessResponse(userService.getUserInfo(userId)));

--- a/src/main/java/com/example/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserController.java
@@ -30,10 +30,12 @@ public class UserController {
 
     /**
      * GUEST 사용자에 한해서 닉네임 중복 여/부를 확인하는 api
+     * TODO. 현재는 중복 체크는 GUEST 유저에게만 허용
      */
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_GUEST')")
     @GetMapping("/check-nickname")
-    public ResponseEntity<ResponseBody<Void>> checkNicknameDuplicate(@Param("nickname") @Pattern(regexp = NICKNAME_REGEXP) String nickname) {
+    public ResponseEntity<ResponseBody<Void>> checkNicknameDuplicate(
+            @Param("nickname") @Pattern(regexp = NICKNAME_REGEXP, message = "닉네임 정규식을 맞춰주세요.") String nickname) {
         userService.checkNicknameDuplicate(nickname);
         return ResponseEntity.ok(createSuccessResponse());
     }

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -103,4 +103,12 @@ public class User extends BaseEntity {
     public void addSeminarApplications(SeminarApplication seminarApplication) {
         this.seminarApplications.add(seminarApplication);
     }
+
+    public void updateUserRoleToActiveUser() {
+        this.role = Role.ROLE_ACTIVE_USER;
+    }
+
+    public void updateUserRoleToSeminarWriter() {
+        this.role = Role.ROLE_SEMINAR_WRITER;
+    }
 }

--- a/src/main/java/com/example/demo/domain/user/domain/dto/request/CompleteRegistrationRequest.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/request/CompleteRegistrationRequest.java
@@ -6,9 +6,9 @@ import jakarta.validation.constraints.Pattern;
 import static com.example.demo.global.regex.UserRegex.NICKNAME_REGEXP;
 
 public record CompleteRegistrationRequest(
-        @Pattern(regexp = NICKNAME_REGEXP)
+        @Pattern(regexp = NICKNAME_REGEXP, message = "닉네임 정규식을 맞춰주세요.")
         String nickname,
-        @NotBlank
+        @NotBlank(message = "이름은 빈값일 수 없습니다.")
         String name
 ) {
 }

--- a/src/main/java/com/example/demo/domain/user/domain/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/request/UpdateNicknameRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Pattern;
 import static com.example.demo.global.regex.UserRegex.NICKNAME_REGEXP;
 
 public record UpdateNicknameRequest(
-        @Pattern(regexp = NICKNAME_REGEXP)
+        @Pattern(regexp = NICKNAME_REGEXP, message = "닉네임 정규식을 맞춰주세요.")
         String nickname
 ) {
 }

--- a/src/main/java/com/example/demo/domain/user/domain/dto/request/UpdateProfileImageRequest.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/request/UpdateProfileImageRequest.java
@@ -3,7 +3,7 @@ package com.example.demo.domain.user.domain.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record UpdateProfileImageRequest(
-        @NotBlank
+        @NotBlank(message = "이미지는 빈값일 수 없습니다.")
         String profileImage
 ) {
 }

--- a/src/main/java/com/example/demo/domain/user/domain/vo/Role.java
+++ b/src/main/java/com/example/demo/domain/user/domain/vo/Role.java
@@ -1,7 +1,9 @@
 package com.example.demo.domain.user.domain.vo;
 
-public enum Role { // TODO : 고민 필요
-    ROLE_GUEST,
-    ROLE_USER,
-    ROLE_ADMIN
+public enum Role {
+    ROLE_GUEST, // 정보가 존재하지 않는 첫 로그인한 사용자
+    ROLE_USER, // 일반 사용자 (댓글 작성 및 뉴스레터 구독 같은 자잘한 활동 가능)
+    ROLE_ACTIVE_USER, // 추가정보를 입력한 사용자 (세미나 신청, 스터디/프로젝트 글 작성 및 신청 가능)
+    ROLE_SEMINAR_WRITER, // 세미나 신청을 한 번 이상한 사용자 (세미나 글 작성 가능)
+    ROLE_ADMIN // 관리용 계정
 }

--- a/src/main/java/com/example/demo/domain/user_addtional_info/controller/UserAdditionalInfoController.java
+++ b/src/main/java/com/example/demo/domain/user_addtional_info/controller/UserAdditionalInfoController.java
@@ -26,7 +26,7 @@ public class UserAdditionalInfoController {
      * 존재하면 UserAdditionalInfoResponse
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @GetMapping("/me")
     public ResponseEntity<ResponseBody<UserAdditionalInfoResponse>> getUserAdditionalInfo(Long userId) {
         return ResponseEntity.ok(createSuccessResponse(userAdditionalInfoService.getUserAdditionalInfo(userId)));
@@ -37,7 +37,7 @@ public class UserAdditionalInfoController {
      * 존재하면 404
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER','ROLE_ADMIN')")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PostMapping("/me")
     public ResponseEntity<ResponseBody<Void>> createUserAdditionalInfo(Long userId,
                                                                        @RequestBody @Valid CreateUserAdditionalInfoRequest request) {

--- a/src/main/java/com/example/demo/domain/user_addtional_info/controller/UserAdditionalInfoController.java
+++ b/src/main/java/com/example/demo/domain/user_addtional_info/controller/UserAdditionalInfoController.java
@@ -15,7 +15,7 @@ import static com.example.demo.global.base.dto.ResponseUtil.createSuccessRespons
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/userAdditionalInfos")
+@RequestMapping("/api/v1/userAdditionalInfos")
 public class UserAdditionalInfoController {
 
     private final UserAdditionalInfoService userAdditionalInfoService;

--- a/src/main/java/com/example/demo/domain/user_addtional_info/controller/UserAdditionalInfoController.java
+++ b/src/main/java/com/example/demo/domain/user_addtional_info/controller/UserAdditionalInfoController.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.user_addtional_info.controller;
 
+import com.example.demo.domain.token.domain.dto.TokenResponse;
 import com.example.demo.domain.user_addtional_info.domain.dto.request.CreateUserAdditionalInfoRequest;
 import com.example.demo.domain.user_addtional_info.domain.dto.response.UserAdditionalInfoResponse;
 import com.example.demo.domain.user_addtional_info.service.UserAdditionalInfoService;
@@ -34,14 +35,14 @@ public class UserAdditionalInfoController {
 
     /**
      * 사용자 추가 정보 생성 api
-     * 존재하면 404
+     * 존재하면 409
+     * 존재하지 않으면 첫 생성이므로, 권한 업데이트 이후 새 토큰을 발급
      */
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PostMapping("/me")
-    public ResponseEntity<ResponseBody<Void>> createUserAdditionalInfo(Long userId,
-                                                                       @RequestBody @Valid CreateUserAdditionalInfoRequest request) {
-        userAdditionalInfoService.createUserAdditionalInfo(userId, request);
-        return ResponseEntity.ok(createSuccessResponse());
+    public ResponseEntity<ResponseBody<TokenResponse>> createUserAdditionalInfo(Long userId,
+                                                                                @RequestBody @Valid CreateUserAdditionalInfoRequest request) {
+        return ResponseEntity.ok(createSuccessResponse( userAdditionalInfoService.createUserAdditionalInfo(userId, request)));
     }
 }

--- a/src/main/java/com/example/demo/domain/user_addtional_info/domain/dto/request/CreateUserAdditionalInfoRequest.java
+++ b/src/main/java/com/example/demo/domain/user_addtional_info/domain/dto/request/CreateUserAdditionalInfoRequest.java
@@ -3,13 +3,16 @@ package com.example.demo.domain.user_addtional_info.domain.dto.request;
 import com.example.demo.domain.user_addtional_info.domain.vo.StudentStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
 public record CreateUserAdditionalInfoRequest(
-        @NotBlank String email,
-        @NotBlank String department,
-        @NotNull int studentId,
-        @NotNull int grade,
-        @NotNull StudentStatus studentStatus,
-        @NotBlank String phoneNumber
+        @Pattern(regexp = EMAIL_REGEXP, message = "이메일 형식에 맞춰주세요.") String email,
+        @NotBlank(message = "학과는 빈 값일 수 없습니다.") String department,
+        @NotNull(message = "학번은 빈 값일 수 없습니다.") int studentId,
+        @NotNull(message = "학년은 빈 값일 수 없습니다.") int grade,
+        @NotNull(message = "재적 상태는 빈 값일 수 없습니다.") StudentStatus studentStatus, // TODO. 커스텀 어노테이션으로 수정
+        @NotBlank(message = "전화번호는 빈 값일 수 없습니다.") String phoneNumber
 ) {
 }

--- a/src/main/java/com/example/demo/domain/user_addtional_info/service/UserAdditionalInfoService.java
+++ b/src/main/java/com/example/demo/domain/user_addtional_info/service/UserAdditionalInfoService.java
@@ -1,11 +1,14 @@
 package com.example.demo.domain.user_addtional_info.service;
 
+import com.example.demo.domain.token.domain.dto.TokenResponse;
 import com.example.demo.domain.user.domain.User;
 import com.example.demo.domain.user.service.UserService;
 import com.example.demo.domain.user_addtional_info.domain.UserAdditionalInfo;
 import com.example.demo.domain.user_addtional_info.domain.dto.request.CreateUserAdditionalInfoRequest;
 import com.example.demo.domain.user_addtional_info.domain.dto.response.UserAdditionalInfoResponse;
 import com.example.demo.global.base.exception.ServiceException;
+import com.example.demo.global.jwt.JwtHandler;
+import com.example.demo.global.jwt.JwtUserClaim;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +23,7 @@ import static com.example.demo.global.base.exception.ErrorCode.USER_ADDITIONAL_I
 public class UserAdditionalInfoService {
 
     private final UserService userService;
+    private final JwtHandler jwtHandler;
 
     public UserAdditionalInfoResponse getUserAdditionalInfo(Long userId) {
         User user = userService.validateUser(userId);
@@ -34,11 +38,13 @@ public class UserAdditionalInfoService {
     }
 
     @Transactional
-    public void createUserAdditionalInfo(Long userId, @Valid CreateUserAdditionalInfoRequest request) {
+    public TokenResponse createUserAdditionalInfo(Long userId, @Valid CreateUserAdditionalInfoRequest request) {
         User user = userService.validateUser(userId);
         if (user.getUserAdditionalInfo() != null) {
             throw new ServiceException(USER_ADDITIONAL_INFO_CONFLICT);
         }
         user.mapAdditionalInfo(UserAdditionalInfo.from(request));
+        user.updateUserRoleToActiveUser(); // 처음 사용자 추가 정보를 작성하면, ACTIVE_USER 로 권한 업데이트
+        return jwtHandler.createTokens(JwtUserClaim.create(user)); // 업데이트된 새 토큰 발급
     }
 }

--- a/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
@@ -14,6 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -72,5 +76,19 @@ public class SecurityConfig {
             TokenProvider tokenProvider
     ) {
         return new ProviderManager(tokenProvider);
+    }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
+        roleHierarchyImpl.setHierarchy("ROLE_ADMIN > ROLE_SEMINAR_WRITER > ROLE_ACTIVE_USER > ROLE_USER > ROLE_GUEST");
+        return roleHierarchyImpl;
+    }
+
+    @Bean
+    public MethodSecurityExpressionHandler expressionHandler(RoleHierarchy roleHierarchy) {
+        DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
+        expressionHandler.setRoleHierarchy(roleHierarchy);
+        return expressionHandler;
     }
 }

--- a/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
     @Bean
     public RoleHierarchy roleHierarchy() {
         RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
-        roleHierarchyImpl.setHierarchy("ROLE_ADMIN > ROLE_SEMINAR_WRITER > ROLE_ACTIVE_USER > ROLE_USER > ROLE_GUEST");
+        roleHierarchyImpl.setHierarchy("ROLE_ADMIN > ROLE_SEMINAR_WRITER > ROLE_ACTIVE_USER > ROLE_USER");
         return roleHierarchyImpl;
     }
 


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
<img width="880" alt="image" src="https://github.com/user-attachments/assets/cb9b888c-78ab-48bd-82fe-1398a7f80d7b">

- 다음과 같이 5개의 권한을 설정하고, 계층 구조를 형성했습니다.
- GUEST 유저는 초기 정보를 입력하기 전까지 사용할 수 있는 권한이 없기에 계층에선 제외했습니다.
- 추가정보 입력 시, 세미나 신청 폼 처음 작성 시 권한 변경 및 토큰 재발급을 구현했습니다.
- 권한 부분은 다 같이 사용하는 부분이라 빠르게 개발해서 올렸습니다.

### ❓ 리뷰 포인트
- validation은 간단하게 보고 넘어가시면 될 듯 합니당.
- 세미나 신청폼 구현에 있어서 처음 작성한다면 200 상태코드와 토큰을 전달하고, 처음이 아니라면 204 상태코드와 빈 값을 전달하도록 구현했습니다.
- 권한을 업데이트하고 토큰을 재발급함에 있어서 refresh토큰을 제거하는 작업을 추가하는 부분에 대해 고민중입니다. 로그아웃 api의 메서드를 사용해서 refresh 토큰을 제거하고, 추후 로그아웃 api에 블랙리스트 기능이 추가되더라도 재발급 쪽에서 큰 변경없이 사용할 수 있을 듯 합니다.
### 🦄 관련 이슈
resolves #83  <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
