### PR TITLE
[#87] 댓글 신고 기능에 디스코드 알림 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ configurations {
     asciidoctorExt
 }
 
+ext {
+    snippetsDir = file('build/generated-snippets')
+    set('springCloudVersion', "2023.0.0")
+}
+
 repositories {
     mavenCentral()
 }
@@ -74,10 +79,15 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
-ext {
-    snippetsDir = file('build/generated-snippets')
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 test {

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -2,8 +2,10 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableFeignClients
 @SpringBootApplication
 public class DemoApplication {
 

--- a/src/main/java/com/example/demo/domain/report/api/ReportController.java
+++ b/src/main/java/com/example/demo/domain/report/api/ReportController.java
@@ -13,7 +13,7 @@ import static com.example.demo.global.base.dto.ResponseUtil.createSuccessRespons
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/reports")
+@RequestMapping("/api/v1/reports")
 public class ReportController {
 
     private final ReportService reportService;
@@ -22,20 +22,20 @@ public class ReportController {
      * 신고하기 - comment
      */
     @AssignUserId
-    @PostMapping("/comment/{commentId}")
+    @PostMapping("/comments/{commentId}")
     public ResponseEntity<ResponseBody<Void>> report(@PathVariable Long commentId,
                                                      Long userId) {
         reportService.report(commentId, userId);
         return ResponseEntity.ok(createSuccessResponse());
     }
 
-    /**
-     * 관리자 기능 - 모든 신고목록 보기
-     */
-    @GetMapping
-    public ResponseEntity<ResponseBody<Page<ReportResponse>>> findAll(@RequestParam(defaultValue = "0") int page,
-                                                                      @RequestParam(defaultValue = "10") int size) {
-
-        return ResponseEntity.ok(createSuccessResponse(reportService.findAll(page,size)));
-    }
+//    /**
+//     * 관리자 기능 - 모든 신고목록 보기
+//     */
+//    @GetMapping
+//    public ResponseEntity<ResponseBody<Page<ReportResponse>>> findAll(@RequestParam(defaultValue = "0") int page,
+//                                                                      @RequestParam(defaultValue = "10") int size) {
+//
+//        return ResponseEntity.ok(createSuccessResponse(reportService.findAll(page,size)));
+//    }
 }

--- a/src/main/java/com/example/demo/domain/report/client/DiscordClient.java
+++ b/src/main/java/com/example/demo/domain/report/client/DiscordClient.java
@@ -1,0 +1,14 @@
+package com.example.demo.domain.report.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "discord-client",
+        url = "${discord.webhook.url}")
+public interface DiscordClient {
+
+    @PostMapping
+    void sendAlarm(@RequestBody DiscordMessage message);
+}

--- a/src/main/java/com/example/demo/domain/report/client/DiscordMessage.java
+++ b/src/main/java/com/example/demo/domain/report/client/DiscordMessage.java
@@ -1,0 +1,55 @@
+package com.example.demo.domain.report.client;
+
+import com.example.demo.domain.comment.domain.entity.Comment;
+import com.example.demo.domain.user.domain.User;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DiscordMessage {
+
+    private String content;
+    private List<Embed> embeds;
+
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    public static class Embed {
+
+        private String title;
+        private String description;
+    }
+
+    public static DiscordMessage createCommentReportMessage(User user, Comment comment) {
+        return DiscordMessage.builder()
+                .content("# 🚨 댓글 신고가 접수되었습니다!!!")
+                .embeds(
+                        List.of(
+                                Embed.builder()
+                                        .title("ℹ️ 신고 댓글 정보")
+                                        .description(
+                                                "### 🕖 발생 시간\n"
+                                                        + LocalDateTime.now()
+                                                        + "\n"
+                                                        + "### 🔗 신고한 사람\n"
+                                                        + user.getNickname()
+                                                        + "\n"
+                                                        + "### 📄 신고 댓글의 정보\n"
+                                                        + "```json\n"
+                                                        + "댓글 아이디 : " + comment.getId() + ",\n"
+                                                        + "작성자 : " + comment.getUser().getNickname() + ",\n"
+                                                        + "댓글 정보 : " + comment.getContent() + ",\n"
+                                                        + "댓글 생성 시간 : " + comment.getCreatedAt()
+                                                        + "\n```")
+                                        .build()
+                        )
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/domain/report/domain/Report.java
+++ b/src/main/java/com/example/demo/domain/report/domain/Report.java
@@ -31,4 +31,8 @@ public class Report extends BaseEntity {
         this.user = user;
         this.comment = comment;
     }
+
+    public static Report from(User user, Comment comment) {
+        return new Report(user, comment);
+    }
 }

--- a/src/main/java/com/example/demo/global/base/exception/CustomErrorDecoder.java
+++ b/src/main/java/com/example/demo/global/base/exception/CustomErrorDecoder.java
@@ -1,0 +1,21 @@
+package com.example.demo.global.base.exception;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.example.demo.global.base.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+public class CustomErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(final String methodKey, final Response response) {
+        log.warn("statusCode[{}], methodKey[{}]", response.status(), methodKey);
+
+        return switch (response.status()) {
+            // TODO. 추가로 필요하다면 처리
+            default -> new ServiceException(INTERNAL_SERVER_ERROR);
+        };
+    }
+}


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 댓글 신고 기능에 디스코드 알림 연동
### ❓ 리뷰 포인트
- RestTemplate 을 사용하면 가독성이 떨어지고 개발할 부분도 많아지고, Web Client를 사용하기엔 댓글 신고가 엄청 많은 정도도 아니고, 사용자 1000명 이하로는 동기방법과 크게 차이가 없다는 지표를 확인해서 interface 형식으로 개발에 용이하고 동기적인 방법인 Feign Client 를 사용해서 연동했습니다. 
- Feign Client의 큰 설정은 없고 yml 쪽에서 default 설정과 discord 서버에서 오류가 나면 500으로 커스텀해서 보내는 정도만 구현했습니다.
- `git submodule update --remote` 서브모듈 업데이트 해주세요!
- 모든 신고를 보는 api는 admin 쪽으로 빼기위해 잠시 주석처리 했습니다.
### 🦄 관련 이슈
resolves #87 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
