### PR TITLE
[#92] 프로필 이미지 설정 및 이메일 전송 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,10 @@ dependencies {
 
     // Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // Thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/example/demo/domain/newsletter/client/DiscordNewsletterClient.java
+++ b/src/main/java/com/example/demo/domain/newsletter/client/DiscordNewsletterClient.java
@@ -1,0 +1,15 @@
+package com.example.demo.domain.newsletter.client;
+
+import com.example.demo.domain.report.client.DiscordMessage;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "discord-newsletter-client",
+        url = "${discord.webhook.url.newsletter}")
+public interface DiscordNewsletterClient {
+
+    @PostMapping
+    void sendNewsletter(@RequestBody DiscordMessage message);
+}

--- a/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
@@ -17,8 +17,6 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "newsletters")
-@SQLDelete(sql = "UPDATE newsletters SET deleted_at = NOW() where id=?")
-@SQLRestriction(value = "deleted_at is NULL")
 public class Newsletter extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/demo/domain/newsletter/event/EmailNotificationEvent.java
+++ b/src/main/java/com/example/demo/domain/newsletter/event/EmailNotificationEvent.java
@@ -2,12 +2,17 @@ package com.example.demo.domain.newsletter.event;
 
 import com.example.demo.domain.newsletter.strategy.EmailDeliveryStrategy;
 import com.example.demo.domain.study_project_board.domain.dto.vo.BoardType;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class EmailNotificationEvent {
     private final BoardType boardType;
     private final EmailDeliveryStrategy emailStrategy;
+
+    public static EmailNotificationEvent create(BoardType boardType, EmailDeliveryStrategy emailStrategy) {
+        return new EmailNotificationEvent(boardType, emailStrategy);
+    }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/event/EmailNotificationEvent.java
+++ b/src/main/java/com/example/demo/domain/newsletter/event/EmailNotificationEvent.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.newsletter.event;
+
+import com.example.demo.domain.newsletter.strategy.EmailDeliveryStrategy;
+import com.example.demo.domain.study_project_board.domain.dto.vo.BoardType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailNotificationEvent {
+    private final BoardType boardType;
+    private final EmailDeliveryStrategy emailStrategy;
+}

--- a/src/main/java/com/example/demo/domain/newsletter/event/NewsletterEventListener.java
+++ b/src/main/java/com/example/demo/domain/newsletter/event/NewsletterEventListener.java
@@ -1,0 +1,24 @@
+package com.example.demo.domain.newsletter.event;
+
+import com.example.demo.domain.newsletter.repository.NewsletterRepository;
+import com.example.demo.domain.newsletter.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class NewsletterEventListener {
+
+    private final NewsletterRepository newsletterRepository;
+    private final EmailService emailService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePostCreatedEvent(EmailNotificationEvent event) {
+        List<String> subscriberEmails = newsletterRepository.findSubscriberEmails(String.valueOf(event.getBoardType()));
+        emailService.sendEmailNotice(subscriberEmails, event.getEmailStrategy());
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
@@ -6,6 +6,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
     boolean existsByEmail(String email);
+
+    @Query("SELECT n.email FROM Newsletter n WHERE " +
+            "(:postType = 'SEMINAR_NOTICE' OR " +
+            "(n.isSeminarContentUpdated = true AND :postType = 'SEMINAR_SUMMARY') OR " +
+            "(n.isStudyUpdated = true AND :postType = 'STUDY') OR " +
+            "(n.isProjectUpdated = true AND :postType = 'PROJECT'))")
+    List<String> findSubscriberEmails(@Param("postType") String postType);
 }

--- a/src/main/java/com/example/demo/domain/newsletter/service/EmailService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/EmailService.java
@@ -23,7 +23,7 @@ public class EmailService {
 
     private final JavaMailSender javaMailSender;
     private final TemplateEngine templateEngine;
-    
+    private final DiscordNewsletterClient discordNewsletterClient;
 
     @Async
     public void sendEmailNotice(List<String> subscriberEmails, EmailDeliveryStrategy emailStrategy) {
@@ -46,7 +46,7 @@ public class EmailService {
                 throw new RuntimeException(e);
             }
         }
-
+        this.sendDiscordNotification(emailStrategy); // 모든 이메일 전송이 끝나면 디스코드로 알림
     }
 
     private String generateHtmlContent(EmailDeliveryStrategy emailStrategy) {
@@ -55,4 +55,7 @@ public class EmailService {
         return templateEngine.process(emailStrategy.getTemplateName(), context);
     }
 
+    private void sendDiscordNotification(EmailDeliveryStrategy emailStrategy) {
+        discordNewsletterClient.sendNewsletter(DiscordMessage.createNewsletterMessage(emailStrategy));
+    }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/service/EmailService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/EmailService.java
@@ -1,0 +1,58 @@
+package com.example.demo.domain.newsletter.service;
+
+import com.example.demo.domain.newsletter.client.DiscordNewsletterClient;
+import com.example.demo.domain.newsletter.strategy.EmailDeliveryStrategy;
+import com.example.demo.domain.report.client.DiscordMessage;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
+    
+
+    @Async
+    public void sendEmailNotice(List<String> subscriberEmails, EmailDeliveryStrategy emailStrategy) {
+        log.info("Trying to send Email to {}", subscriberEmails);
+        // TODO. 성능에 이상이 있다면 bcc 방식으로 변경 예정
+        for (String email : subscriberEmails) {
+            try {
+                MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+                MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+                mimeMessageHelper.setTo(new InternetAddress(email, "구독자"));
+                mimeMessageHelper.setSubject(emailStrategy.getSubject());
+
+                String htmlContent = generateHtmlContent(emailStrategy);
+                mimeMessageHelper.setText(htmlContent, true);
+
+                javaMailSender.send(mimeMessage);
+                log.info("Succeeded to send Email to {}", subscriberEmails);
+            } catch (Exception e) {
+                log.info("Failed to send Email to {}, Error log: ", subscriberEmails, e);
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    private String generateHtmlContent(EmailDeliveryStrategy emailStrategy) {
+        Context context = new Context();
+        context.setVariables(emailStrategy.getVariables());
+        return templateEngine.process(emailStrategy.getTemplateName(), context);
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/EmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/EmailDeliveryStrategy.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.newsletter.strategy;
+
+import java.util.Map;
+
+public interface EmailDeliveryStrategy {
+    String getTemplateName();
+    Map<String, Object> getVariables();
+    String getSubject();
+}

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/ProjectNoticeEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/ProjectNoticeEmailDeliveryStrategy.java
@@ -1,0 +1,54 @@
+package com.example.demo.domain.newsletter.strategy;
+
+import com.example.demo.domain.study_project_board.domain.dto.vo.StudyProjectBoardType;
+import com.example.demo.domain.study_project_board.domain.entity.StudyProjectBoard;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProjectNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy {
+    private String type;
+    private String tag;
+    private String title;
+    private String author;
+    private String link;
+
+    @Override
+    public String getTemplateName() {
+        return "project_team_notice";
+    }
+
+    @Override
+    public Map<String, Object> getVariables() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("type", type);
+        variables.put("tag", tag);
+        variables.put("title", title);
+        variables.put("author", author);
+        variables.put("link", link);
+        return variables;
+    }
+
+    @Override
+    public String getSubject() {
+        return "[야밤의금오톡] '프로젝트 팀원 공고' 새 글 알림";
+    }
+
+    public static ProjectNoticeEmailDeliveryStrategy create(StudyProjectBoard studyProjectBoard) {
+        if (!studyProjectBoard.getType().equals(StudyProjectBoardType.PROJECT)) {
+            throw new IllegalArgumentException("스터디에 대한 이메일 알림만 허용합니다.");
+        }
+        return new ProjectNoticeEmailDeliveryStrategy(
+                studyProjectBoard.getType().name(),
+                studyProjectBoard.getTag().name(),
+                studyProjectBoard.getTitle(),
+                studyProjectBoard.getUser().getNickname(),
+                "https://프론트도메인/~" // TODO. 수정 필요
+        );
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/SeminarSummaryEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/SeminarSummaryEmailDeliveryStrategy.java
@@ -1,0 +1,48 @@
+package com.example.demo.domain.newsletter.strategy;
+
+import com.example.demo.domain.board.domain.dto.vo.Tag;
+import com.example.demo.domain.board.domain.entity.Board;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SeminarSummaryEmailDeliveryStrategy implements EmailDeliveryStrategy {
+    private String title;
+    private String author;
+    private String link;
+
+    @Override
+    public String getTemplateName() {
+        return "seminar_notice";
+    }
+
+    @Override
+    public Map<String, Object> getVariables() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("title", title);
+        variables.put("author", author);
+        variables.put("link", link);
+        return variables;
+    }
+
+    @Override
+    public String getSubject() {
+        return "[야밤의금오톡] '세미나 발표 정리' 새 글 알림";
+    }
+
+    public static SeminarSummaryEmailDeliveryStrategy create(Board board) {
+        if (!board.getTag().equals(Tag.seminar)) {
+            throw new IllegalArgumentException("세미나 내용 정리에 대한 이메일 알림만 허용합니다.");
+        }
+        return new SeminarSummaryEmailDeliveryStrategy(
+                board.getTitle(),
+                board.getUser().getNickname(),
+                "https://프론트도메인/~" // TODO. 수정 필요
+        );
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/StudyNoticeEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/StudyNoticeEmailDeliveryStrategy.java
@@ -1,0 +1,54 @@
+package com.example.demo.domain.newsletter.strategy;
+
+import com.example.demo.domain.study_project_board.domain.dto.vo.StudyProjectBoardType;
+import com.example.demo.domain.study_project_board.domain.entity.StudyProjectBoard;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StudyNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy {
+    private String type;
+    private String tag;
+    private String title;
+    private String author;
+    private String link;
+
+    @Override
+    public String getTemplateName() {
+        return "study_team_notice";
+    }
+
+    @Override
+    public Map<String, Object> getVariables() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("type", type);
+        variables.put("tag", tag);
+        variables.put("title", title);
+        variables.put("author", author);
+        variables.put("link", link);
+        return variables;
+    }
+
+    @Override
+    public String getSubject() {
+        return "[야밤의금오톡] '스터디 팀원 공고' 새 글 알림";
+    }
+
+    public static StudyNoticeEmailDeliveryStrategy create(StudyProjectBoard studyProjectBoard) {
+        if (!studyProjectBoard.getType().equals(StudyProjectBoardType.STUDY)) {
+            throw new IllegalArgumentException("스터디에 대한 이메일 알림만 허용합니다.");
+        }
+        return new StudyNoticeEmailDeliveryStrategy(
+                studyProjectBoard.getType().name(),
+                studyProjectBoard.getTag().name(),
+                studyProjectBoard.getTitle(),
+                studyProjectBoard.getUser().getNickname(),
+                "https://프론트도메인/~" // TODO. 수정 필요
+        );
+    }
+}

--- a/src/main/java/com/example/demo/domain/report/client/DiscordMessage.java
+++ b/src/main/java/com/example/demo/domain/report/client/DiscordMessage.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.report.client;
 
 import com.example.demo.domain.comment.domain.entity.Comment;
+import com.example.demo.domain.newsletter.strategy.EmailDeliveryStrategy;
 import com.example.demo.domain.user.domain.User;
 import lombok.*;
 
@@ -21,7 +22,6 @@ public class DiscordMessage {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
     public static class Embed {
-
         private String title;
         private String description;
     }
@@ -47,6 +47,26 @@ public class DiscordMessage {
                                                         + "댓글 정보 : " + comment.getContent() + ",\n"
                                                         + "댓글 생성 시간 : " + comment.getCreatedAt()
                                                         + "\n```")
+                                        .build()
+                        )
+                )
+                .build();
+    }
+
+    public static DiscordMessage createNewsletterMessage(EmailDeliveryStrategy emailDeliveryStrategy) {
+        return DiscordMessage.builder()
+                .content("# 📬 이메일 알림이 전송되었습니다!!!")
+                .embeds(
+                        List.of(
+                                Embed.builder()
+                                        .title("ℹ️ 알림 정보")
+                                        .description(
+                                                "### 🕖 발생 시간\n"
+                                                        + LocalDateTime.now()
+                                                        + "\n"
+                                                        + "### 🎈 알림 주제\n"
+                                                        + emailDeliveryStrategy.getSubject()
+                                                        + "\n")
                                         .build()
                         )
                 )

--- a/src/main/java/com/example/demo/domain/report/client/DiscordReportClient.java
+++ b/src/main/java/com/example/demo/domain/report/client/DiscordReportClient.java
@@ -5,10 +5,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(
-        name = "discord-client",
-        url = "${discord.webhook.url}")
-public interface DiscordClient {
+        name = "discord-report-client",
+        url = "${discord.webhook.url.report}")
+public interface DiscordReportClient {
 
     @PostMapping
-    void sendAlarm(@RequestBody DiscordMessage message);
+    void sendReport(@RequestBody DiscordMessage message);
 }

--- a/src/main/java/com/example/demo/domain/report/controller/ReportController.java
+++ b/src/main/java/com/example/demo/domain/report/controller/ReportController.java
@@ -1,11 +1,9 @@
-package com.example.demo.domain.report.api;
+package com.example.demo.domain.report.controller;
 
-import com.example.demo.domain.report.application.ReportService;
-import com.example.demo.domain.report.dto.ReportResponse;
+import com.example.demo.domain.report.service.ReportService;
 import com.example.demo.global.aop.AssignUserId;
 import com.example.demo.global.base.dto.ResponseBody;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/demo/domain/report/domain/dto/ReportResponse.java
+++ b/src/main/java/com/example/demo/domain/report/domain/dto/ReportResponse.java
@@ -1,4 +1,4 @@
-package com.example.demo.domain.report.dto;
+package com.example.demo.domain.report.domain.dto;
 
 import com.example.demo.domain.comment.domain.response.CommentInfoResponse;
 import com.example.demo.domain.report.domain.Report;

--- a/src/main/java/com/example/demo/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/demo/domain/report/service/ReportService.java
@@ -1,11 +1,11 @@
-package com.example.demo.domain.report.application;
+package com.example.demo.domain.report.service;
 
 import com.example.demo.domain.comment.domain.entity.Comment;
 import com.example.demo.domain.comment.repository.CommentRepository;
-import com.example.demo.domain.report.client.DiscordClient;
+import com.example.demo.domain.report.client.DiscordReportClient;
 import com.example.demo.domain.report.client.DiscordMessage;
 import com.example.demo.domain.report.domain.Report;
-import com.example.demo.domain.report.dto.ReportResponse;
+import com.example.demo.domain.report.domain.dto.ReportResponse;
 import com.example.demo.domain.report.repository.ReportRepository;
 import com.example.demo.domain.user.domain.User;
 import com.example.demo.domain.user.repository.UserRepository;
@@ -26,7 +26,7 @@ public class ReportService {
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
-    private final DiscordClient discordClient;
+    private final DiscordReportClient discordReportClient;
 
     @Transactional
     public void report(Long commentId, Long userId) {
@@ -40,7 +40,7 @@ public class ReportService {
     }
 
     private void sendDiscordAlarm(User user, Comment comment) {
-        discordClient.sendAlarm(DiscordMessage.createCommentReportMessage(user, comment));
+        discordReportClient.sendReport(DiscordMessage.createCommentReportMessage(user, comment));
     }
 
     public Page<ReportResponse> findAll(int page, int size) {

--- a/src/main/java/com/example/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserController.java
@@ -6,7 +6,6 @@ import static com.example.demo.global.regex.UserRegex.NICKNAME_REGEXP;
 
 import com.example.demo.domain.token.domain.dto.TokenResponse;
 import com.example.demo.domain.user.domain.dto.request.UpdateNicknameRequest;
-import com.example.demo.domain.user.domain.dto.request.UpdateProfileImageRequest;
 import com.example.demo.domain.user.domain.dto.response.UserInfo;
 import com.example.demo.domain.user.service.UserService;
 import com.example.demo.domain.user.domain.dto.request.CompleteRegistrationRequest;
@@ -72,18 +71,6 @@ public class UserController {
     public ResponseEntity<ResponseBody<Void>> updateNickname(@RequestBody @Valid UpdateNicknameRequest request,
                                                                       Long userId) {
         userService.updateNickname(userId, request);
-        return ResponseEntity.ok(createSuccessResponse());
-    }
-
-    /**
-     * 사용자 프로필 이미지 수정 api
-     */
-    @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
-    @PatchMapping("/me/profileImage")
-    public ResponseEntity<ResponseBody<Void>> updateProfileImage(@RequestBody @Valid UpdateProfileImageRequest request,
-                                                                 Long userId) {
-        userService.updateProfileImage(userId, request);
         return ResponseEntity.ok(createSuccessResponse());
     }
 

--- a/src/main/java/com/example/demo/domain/user/controller/UserFileController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserFileController.java
@@ -1,0 +1,39 @@
+package com.example.demo.domain.user.controller;
+
+import com.example.demo.domain.board.domain.dto.request.FileRequest;
+import com.example.demo.domain.user.domain.dto.request.ChangeProfileUrlRequest;
+import com.example.demo.domain.user.domain.dto.request.ProfilePresignedUrlRequest;
+import com.example.demo.domain.user.service.UserFileService;
+import com.example.demo.global.aop.AssignUserId;
+import com.example.demo.global.base.dto.ResponseBody;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.demo.global.base.dto.ResponseUtil.createSuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/files")
+public class UserFileController {
+
+    private final UserFileService userFileService;
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
+    @PostMapping("/presigned-url")
+    public ResponseEntity<ResponseBody<String>> getPresignedUrl(Long userId,
+                                                                @RequestBody @Valid ProfilePresignedUrlRequest request) {
+        return ResponseEntity.ok(createSuccessResponse(userFileService.getPresignedUrl(userId, request)));
+    }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
+    @PatchMapping("/profile")
+    public ResponseEntity<ResponseBody<Void>> changeProfileUrl(Long userId,@RequestBody @Valid ChangeProfileUrlRequest request) {
+        userFileService.changeProfileUrl(userId, request);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -10,6 +10,8 @@ import com.example.demo.domain.user_addtional_info.domain.UserAdditionalInfo;
 import com.example.demo.global.base.domain.BaseEntity;
 import com.example.demo.global.oauth.user.OAuth2Provider;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.SQLDelete;
@@ -43,7 +45,7 @@ public class User extends BaseEntity {
 
     private String name;
 
-    private String profileImage;
+    private String profileImageUrl;
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
@@ -80,16 +82,12 @@ public class User extends BaseEntity {
     public void setInitialInfo(String nickname, String name) {
         this.nickname = nickname;
         this.name = name;
-        this.profileImage = "기본이미지 url";
+        this.profileImageUrl = "기본이미지 url";
         this.role = Role.ROLE_USER;
     }
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
-    }
-
-    public void updateProfileImage( String profileImage) {
-        this.profileImage = profileImage;
     }
 
     public void mapAdditionalInfo(UserAdditionalInfo userAdditionalInfo) {
@@ -110,5 +108,9 @@ public class User extends BaseEntity {
 
     public void updateUserRoleToSeminarWriter() {
         this.role = Role.ROLE_SEMINAR_WRITER;
+    }
+
+    public void changeProfileUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -77,10 +77,10 @@ public class User extends BaseEntity {
         this.role = role;
     }
 
-    public void setInitialInfo(String nickname, String name, String bucket) {
+    public void setInitialInfo(String nickname, String name, String defaultImageUrl) {
         this.nickname = nickname;
         this.name = name;
-        this.profileImageUrl = String.format("https://%s.s3.ap-northeast-2.amazonaws.com/profile/default_profile.png", bucket);
+        this.profileImageUrl = defaultImageUrl;
         this.role = Role.ROLE_USER;
     }
 

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -10,8 +10,6 @@ import com.example.demo.domain.user_addtional_info.domain.UserAdditionalInfo;
 import com.example.demo.global.base.domain.BaseEntity;
 import com.example.demo.global.oauth.user.OAuth2Provider;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.SQLDelete;
@@ -79,10 +77,10 @@ public class User extends BaseEntity {
         this.role = role;
     }
 
-    public void setInitialInfo(String nickname, String name) {
+    public void setInitialInfo(String nickname, String name, String bucket) {
         this.nickname = nickname;
         this.name = name;
-        this.profileImageUrl = "기본이미지 url";
+        this.profileImageUrl = String.format("https://%s.s3.ap-northeast-2.amazonaws.com/profile/default_profile.png", bucket);
         this.role = Role.ROLE_USER;
     }
 

--- a/src/main/java/com/example/demo/domain/user/domain/dto/request/ChangeProfileUrlRequest.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/request/ChangeProfileUrlRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.user.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+import static com.example.demo.global.regex.S3UrlRegex.S3_PROFILE_FILE_URL;
+
+public record ChangeProfileUrlRequest (
+        @NotBlank(message = "파일 url은 필수 입니다.")
+        @Pattern(regexp = S3_PROFILE_FILE_URL)
+        String url
+) {
+}

--- a/src/main/java/com/example/demo/domain/user/domain/dto/request/ProfilePresignedUrlRequest.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/request/ProfilePresignedUrlRequest.java
@@ -1,0 +1,16 @@
+package com.example.demo.domain.user.domain.dto.request;
+
+import com.example.demo.domain.board.domain.dto.vo.FileType;
+import com.example.demo.global.aop.valid.ValidEnum;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProfilePresignedUrlRequest(
+        @NotBlank(message = "파일 이름은 필수입니다.")
+        String fileName,
+
+        @NotNull(message = "파일 타입은 필수입니다.")
+        @ValidEnum(enumClass = FileType.class)
+        FileType fileType
+) {
+}

--- a/src/main/java/com/example/demo/domain/user/domain/dto/request/UpdateProfileImageRequest.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/request/UpdateProfileImageRequest.java
@@ -1,9 +1,0 @@
-package com.example.demo.domain.user.domain.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record UpdateProfileImageRequest(
-        @NotBlank(message = "이미지는 빈값일 수 없습니다.")
-        String profileImage
-) {
-}

--- a/src/main/java/com/example/demo/domain/user/domain/dto/response/UserInfo.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/response/UserInfo.java
@@ -25,7 +25,7 @@ public record UserInfo(
                 user.getProvider(),
                 user.getNickname(),
                 user.getName(),
-                user.getProfileImage(),
+                user.getProfileImageUrl(),
                 user.getRole(),
                 user.getCreatedAt(),
                 user.getUpdatedAt()

--- a/src/main/java/com/example/demo/domain/user/service/UserFileService.java
+++ b/src/main/java/com/example/demo/domain/user/service/UserFileService.java
@@ -1,0 +1,33 @@
+package com.example.demo.domain.user.service;
+
+import com.example.demo.domain.user.domain.User;
+import com.example.demo.domain.user.domain.dto.request.ChangeProfileUrlRequest;
+import com.example.demo.domain.user.domain.dto.request.ProfilePresignedUrlRequest;
+import com.example.demo.global.utils.S3PresignedUrlUtil;
+import com.example.demo.global.utils.S3UrlUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class UserFileService {
+
+    private final UserService userService;
+    private final S3UrlUtil s3UrlUtil;
+    private final S3PresignedUrlUtil s3PresignedUrlUtil;
+
+    public String getPresignedUrl(Long userId, @Valid ProfilePresignedUrlRequest request) {
+        User user = userService.validateUser(userId);
+        String s3Path = s3UrlUtil.generateProfileS3Path(user.getId(), request.fileType().toString(), request.fileName());
+        return s3PresignedUrlUtil.generatePresignedUrl(s3Path);
+    }
+
+    @Transactional
+    public void changeProfileUrl(Long userId, @Valid ChangeProfileUrlRequest request) {
+        User user = userService.validateUser(userId);
+        user.changeProfileUrl(request.url());
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/demo/domain/user/service/UserService.java
@@ -5,7 +5,6 @@ import com.example.demo.domain.token.repository.RefreshTokenRepository;
 import com.example.demo.domain.user.domain.User;
 import com.example.demo.domain.user.domain.dto.request.CompleteRegistrationRequest;
 import com.example.demo.domain.user.domain.dto.request.UpdateNicknameRequest;
-import com.example.demo.domain.user.domain.dto.request.UpdateProfileImageRequest;
 import com.example.demo.domain.user.domain.dto.response.UserInfo;
 import com.example.demo.domain.user.repository.UserRepository;
 import com.example.demo.global.base.exception.ErrorCode;
@@ -56,12 +55,6 @@ public class UserService {
         User user = this.validateUser(userId);
         this.checkNicknameDuplicate(request.nickname());
         user.updateNickname(request.nickname());
-    }
-
-    @Transactional
-    public void updateProfileImage(Long userId, @Valid UpdateProfileImageRequest request) {
-        User user = this.validateUser(userId);
-        user.updateProfileImage(request.profileImage());
     }
 
     public UserInfo getUserInfo(Long userId) {

--- a/src/main/java/com/example/demo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/demo/domain/user/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
         if(userRepository.existsByNickname(request.nickname())){
             throw new ServiceException(ErrorCode.EXIST_SAME_NICKNAME);
         }
-        user.setInitialInfo(request.nickname(), request.name(), s3UrlUtil.bucket);
+        user.setInitialInfo(request.nickname(), request.name(), s3UrlUtil.getDefaultImageUrl());
         return jwtHandler.createTokens(JwtUserClaim.create(user));
     }
 

--- a/src/main/java/com/example/demo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/demo/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.example.demo.global.base.exception.ErrorCode;
 import com.example.demo.global.base.exception.ServiceException;
 import com.example.demo.global.jwt.JwtHandler;
 import com.example.demo.global.jwt.JwtUserClaim;
+import com.example.demo.global.utils.S3UrlUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtHandler jwtHandler;
+    private final S3UrlUtil s3UrlUtil;
 
     public void checkNicknameDuplicate(String nickname) {
         if(userRepository.existsByNickname(nickname)){
@@ -37,7 +39,7 @@ public class UserService {
         if(userRepository.existsByNickname(request.nickname())){
             throw new ServiceException(ErrorCode.EXIST_SAME_NICKNAME);
         }
-        user.setInitialInfo(request.nickname(), request.name());
+        user.setInitialInfo(request.nickname(), request.name(), s3UrlUtil.bucket);
         return jwtHandler.createTokens(JwtUserClaim.create(user));
     }
 

--- a/src/main/java/com/example/demo/global/base/exception/CustomAsyncExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/base/exception/CustomAsyncExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.example.demo.global.base.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+public class CustomAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error("error message: {}", ex.getMessage());
+    }
+}

--- a/src/main/java/com/example/demo/global/config/async/AsyncConfig.java
+++ b/src/main/java/com/example/demo/global/config/async/AsyncConfig.java
@@ -1,0 +1,33 @@
+package com.example.demo.global.config.async;
+
+import com.example.demo.global.base.exception.CustomAsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() { // TODO. 배포 환경에 맞는 설정 변경 필요
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(8);
+        executor.setMaxPoolSize(100);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("task-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new CustomAsyncExceptionHandler();
+    }
+}

--- a/src/main/java/com/example/demo/global/regex/S3UrlRegex.java
+++ b/src/main/java/com/example/demo/global/regex/S3UrlRegex.java
@@ -3,4 +3,6 @@ package com.example.demo.global.regex;
 public interface S3UrlRegex {
 	// S3 버킷 URL 정규식 (https://kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com/board/{boardId}/{image|attach}/uuid/{fileName})
 	String S3_BOARD_FILE_URL = "https:\\/\\/kumoh-talk-bucket\\.s3\\.ap-northeast-2\\.amazonaws\\.com\\/board\\/\\d+\\/(image|attach)\\/.*\\/[a-zA-Z0-9\\.\\-]+";
+
+	String S3_PROFILE_FILE_URL = "https:\\/\\/kumoh-talk-bucket\\.s3\\.ap-northeast-2\\.amazonaws\\.com\\/profile\\/\\d+\\/image\\/.*\\/[a-zA-Z0-9\\.\\-\\_]+";
 }

--- a/src/main/java/com/example/demo/global/utils/S3UrlUtil.java
+++ b/src/main/java/com/example/demo/global/utils/S3UrlUtil.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +18,11 @@ import jakarta.annotation.PostConstruct;
 public class S3UrlUtil {
 
 	@Value("${cloud.aws.s3.bucket}")
-	public String bucket;
+	private String bucket;
+
+	@Getter
+	@Value("${cloud.aws.s3.default-image-url}")
+	private String defaultImageUrl;
 
 	private static final String BOARD_S3_PATH_FORMAT = "board/%s/%s/%s/%s";
 	private static final String PROFILE_S3_PATH_FORMAT = "profile/%s/%s/%s/%s";

--- a/src/main/java/com/example/demo/global/utils/S3UrlUtil.java
+++ b/src/main/java/com/example/demo/global/utils/S3UrlUtil.java
@@ -17,7 +17,7 @@ import jakarta.annotation.PostConstruct;
 public class S3UrlUtil {
 
 	@Value("${cloud.aws.s3.bucket}")
-	private String bucket;
+	public String bucket;
 
 	private static final String BOARD_S3_PATH_FORMAT = "board/%s/%s/%s/%s";
 	private static final String PROFILE_S3_PATH_FORMAT = "profile/%s/%s/%s/%s";

--- a/src/main/resources/templates/project_team_notice.html
+++ b/src/main/resources/templates/project_team_notice.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>[야밤의금오톡] '프로젝트 팀원 공고' 새 글 알림</title>
+</head>
+<body>
+<p>안녕하세요, 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+
+<p>
+    새로운 <strong th:text="${type}">프로젝트 태그</strong>에 함께할 팀원을 구하는 게시글이 게시되었습니다.<br>
+    <strong th:text="${tag}">개발직군 태그</strong>에 관심이 있거나, 함께 의미 있는 프로젝트를 진행해보고 싶은 분들은 아래 게시글을 통해 자세한 내용을 확인해주시기 바랍니다.
+</p>
+
+<ul>
+    <li>
+        <h3>프로젝트 주제 : <span th:text="${title}">게시글 제목</span></h3>
+    </li>
+    <li>
+        <h3>작성자 : <span th:text="${author}">작성자</span></h3>
+    </li>
+    <li>
+        <h3>게시글 바로가기 : <a th:href="${link}">게시글 링크</a></h3>
+    </li>
+</ul>
+
+<p>
+    프로젝트에 참여하여 팀원으로서 함께 협력하고 성장하고자 하는 여러분들의 많은 관심 부탁드립니다.
+</p>
+
+<p>
+    추가 문의사항이 있으신 분들은 게시글 아래 댓글로 문의해주시면 감사하겠습니다.
+</p>
+
+<p>감사합니다.</p>
+
+<p>[야밤의 금오톡 기술 블로그팀]</p>
+</body>
+</html>

--- a/src/main/resources/templates/seminar_notice.html
+++ b/src/main/resources/templates/seminar_notice.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>[야밤의금오톡] '세미나 발표 정리' 새 글 알림</title>
+</head>
+<body>
+<p>안녕하세요, 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+
+<p>지난 야밤의금오톡 IT 세미나에서 진행되었던 내용에 대한 게시물이 업로드 되었습니다.</p>
+
+<p>본 게시글에는 세미나에서 다뤘던 핵심 내용이 간결하게 정리되어 있으니,<br>
+    발표에서 다룬 주요 사항들을 확인하시고 여러분의 학습에 도움이 되기를 바랍니다.</p>
+
+<ul>
+    <li>
+        <h3>주제 : <span th:text="${title}">게시글 제목</span></h3>
+    </li>
+    <li>
+        <h3>작성자 : <span th:text="${author}">작성자</span></h3>
+    </li>
+    <li>
+        <h3>게시글 바로가기 : <a th:href="${link}"> 게시글 링크</a></h3>
+    </li>
+</ul>
+
+<p>
+    세미나의 녹화본을 보고 싶으신 분들은 아래에서 확인하실 수 있습니다.<br>
+    <strong>유튜브 바로가기: </strong>
+    <a href="https://www.youtube.com/@midnight_kumoh_talk">https://www.youtube.com/@midnight_kumoh_talk</a>
+</p>
+
+<p>
+    게시글을 읽으신 후 궁금한 점이나 더 알고 싶은 내용이 있으시면, 댓글로
+    남겨주시면 감사하겠습니다.
+</p>
+
+<p>[야밤의 금오톡 기술 블로그팀]</p>
+</body>
+</html>

--- a/src/main/resources/templates/study_team_notice.html
+++ b/src/main/resources/templates/study_team_notice.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>[야밤의금오톡] '스터디 팀원 공고' 새 글 알림</title>
+</head>
+<body>
+<p>안녕하세요, 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+
+<p>
+    새로운 <strong th:text="${type}">스터디 태그</strong> 그룹을 모집하는 게시글이
+    게시되었습니다.<br />
+    <strong th:text="${tag}">개발직군 태그</strong>에 관심이 있는 분들은 아래 게시글을 통해
+    자세한 내용을 확인해주시기 바랍니다.
+</p>
+
+<ul>
+    <li>
+        <h3>스터디 주제 : <span th:text="${title}">게시글 제목</span></h3>
+    </li>
+    <li>
+        <h3>작성자 : <span th:text="${author}">작성자</span></h3>
+    </li>
+    <li>
+        <h3>게시글 바로가기 : <a th:href="${link}"> 게시글 링크</a></h3>
+    </li>
+</ul>
+
+<p>
+    스터디에 참여하여 함께 학습하고 성장하고자 하는 여러분들의 많은 관심
+    부탁드립니다.
+</p>
+
+<p>
+    추가 문의사항이 있으신 분들은 게시글 아래 댓글로 문의해주시면
+    감사하겠습니다.
+</p>
+
+<p>감사합니다.</p>
+
+<p>[야밤의 금오톡 기술 블로그팀]</p>
+</body>
+</html>


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 프로필 이미지 업로드
- 기본 프로필 이미지 링크 설정
- 뉴스레터 도메인 soft-delete 제거
- 이메일 알림 전송 이벤트리스너 등록
- 비동기 설정

### ❓ 리뷰 포인트
- 기본 프로필 이미지 설정에서 도메인을 숨기기위해 **`S3UrlUtil` 의 버킷을 public으로 변경**했습니다. (사실 정규식에서 이미 나와있어서 의미가 있나 싶긴한데..)
- **뉴스레터 도메인의 soft-delete 설정을 삭제**했습니다. 굳이 저장이 필요하지 않다 생각하며, 구독 취소 후 재구독의 비율이 많을 것 같은 도메인이라 hard-delete 형식을 사용하려 합니다.
- **이메일 전송을 이벤트로 처리하기 위해 이벤트리스너를 등록**했습니다. 실제 세미나 내용정리, 스터디,프로젝트 글 작성시에 해당 이벤트를 전송해야하는데, 그 부분은 제 담당이 아니기에 괜히 건들기 애매해서 사용예제를 남기고, **각자 적용**해주셨으면 합니다!
  - **사용 예제**는 아래와 같습니다.
  <img width="704" alt="image" src="https://github.com/user-attachments/assets/70ce846e-3b98-4095-98d4-6379e04fc870">

  - ApplicationEventPublisher 를 의존성주입으로 받아와 publishEvent 메서드를 통해 이벤트를 전송합니다.
  - EmailNotificationEvent 를 만들어줍니다. 원하는 타입과 전략을 설정해주면 됩니다.
    - 전략을 만들때는 내부 로직을 신경쓸 필요 없도록 도메인을 받아서 필요한 내용을 받아 처리하도록 설정했습니다.
      <img width="836" alt="image" src="https://github.com/user-attachments/assets/dad5278d-4374-4630-adb3-0a6bfa60abcd">

  - 글이 완전히 저장되고, 알림을 보내는 정합성을 보장하기 위해 `@TransactionalEventListener` 을 사용했기에 각 이벤트 전송은 **트랜잭션 안에서 실행**되어야 합니다.

- 추가로 필요한 세미나 공지사항 알림은 백오피스에서 직접 작성하는 방식으로 사용한다고 했기에 추후 ADMIN 기능 개발에서 진행할 예정입니다.


### 🦄 관련 이슈
resolves #92 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
