### PR TITLE
멘토링 관련 알림 폼 및 전략 추가

### DIFF
--- a/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
@@ -25,26 +25,30 @@ public class Newsletter extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
     @Column(nullable = false)
-    private Boolean isSeminarContentUpdated;
+    private Boolean seminarContentNotice;
     @Column(nullable = false)
-    private Boolean isStudyUpdated;
+    private Boolean studyNotice;
     @Column(nullable = false)
-    private Boolean isProjectUpdated;
+    private Boolean projectNotice;
+    @Column(nullable = false)
+    private Boolean mentoringNotice;
 
     @Builder
-    public Newsletter(String email, Boolean isSeminarContentUpdated, Boolean isStudyUpdated, Boolean isProjectUpdated) {
+    public Newsletter(String email, Boolean mentoringNotice, Boolean projectNotice, Boolean seminarContentNotice, Boolean studyNotice) {
         this.email = email;
-        this.isSeminarContentUpdated = isSeminarContentUpdated;
-        this.isStudyUpdated = isStudyUpdated;
-        this.isProjectUpdated = isProjectUpdated;
+        this.mentoringNotice = mentoringNotice;
+        this.projectNotice = projectNotice;
+        this.seminarContentNotice = seminarContentNotice;
+        this.studyNotice = studyNotice;
     }
 
     public static Newsletter from(NewsletterSubscribeRequest request) {
         return Newsletter.builder()
                 .email(request.email())
-                .isSeminarContentUpdated(request.isSeminarContentUpdated())
-                .isStudyUpdated(request.isStudyUpdated())
-                .isProjectUpdated(request.isProjectUpdated())
+                .seminarContentNotice(request.seminarContentNotice())
+                .studyNotice(request.studyNotice())
+                .projectNotice(request.projectNotice())
+                .mentoringNotice(request.mentoringNotice())
                 .build();
     }
 
@@ -53,8 +57,9 @@ public class Newsletter extends BaseEntity {
     }
 
     public void updateNewsletterNotify(@Valid NewsletterUpdateNotifyRequest request) {
-        this.isSeminarContentUpdated = request.isSeminarContentUpdated();
-        this.isStudyUpdated = request.isStudyUpdated();
-        this.isProjectUpdated = request.isProjectUpdated();
+        this.seminarContentNotice = request.seminarContentNotice();
+        this.studyNotice = request.studyNotice();
+        this.projectNotice = request.projectNotice();
+        this.mentoringNotice = request.mentoringNotice();
     }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterSubscribeRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterSubscribeRequest.java
@@ -7,8 +7,9 @@ import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
 public record NewsletterSubscribeRequest(
         @Pattern(regexp = EMAIL_REGEXP, message = "이메일 정규식을 맞춰주세요.") String email,
-        @NotNull(message = "세미나 내용정리 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isSeminarContentUpdated,
-        @NotNull(message = "스터디 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isStudyUpdated,
-        @NotNull(message = "프로젝트 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isProjectUpdated
+        @NotNull(message = "세미나 내용정리 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean seminarContentNotice,
+        @NotNull(message = "스터디 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean studyNotice,
+        @NotNull(message = "프로젝트 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean projectNotice,
+        @NotNull(message = "멘토링 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean mentoringNotice
 ) {
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateNotifyRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateNotifyRequest.java
@@ -6,8 +6,9 @@ import jakarta.validation.constraints.Pattern;
 import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
 public record NewsletterUpdateNotifyRequest(
-        @NotNull(message = "세미나 내용정리 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isSeminarContentUpdated,
-        @NotNull(message = "스터디 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isStudyUpdated,
-        @NotNull(message = "프로젝트 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean isProjectUpdated
+        @NotNull(message = "세미나 내용정리 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean seminarContentNotice,
+        @NotNull(message = "스터디 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean studyNotice,
+        @NotNull(message = "프로젝트 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean projectNotice,
+        @NotNull(message = "멘토링 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean mentoringNotice
 ) {
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/response/NewsletterInfo.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/response/NewsletterInfo.java
@@ -8,9 +8,10 @@ import java.time.LocalDateTime;
 public record NewsletterInfo(
         Long id,
         String email,
-        Boolean isSeminarContentUpdated,
-        Boolean isStudyUpdated,
-        Boolean isProjectUpdated,
+        Boolean seminarContentNotice,
+        Boolean studyNotice,
+        Boolean projectNotice,
+        Boolean mentoringNotice,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime createdAt,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
@@ -20,9 +21,10 @@ public record NewsletterInfo(
         return new NewsletterInfo(
                 newsletter.getId(),
                 newsletter.getEmail(),
-                newsletter.getIsSeminarContentUpdated(),
-                newsletter.getIsStudyUpdated(),
-                newsletter.getIsProjectUpdated(),
+                newsletter.getSeminarContentNotice(),
+                newsletter.getStudyNotice(),
+                newsletter.getProjectNotice(),
+                newsletter.getMentoringNotice(),
                 newsletter.getCreatedAt(),
                 newsletter.getUpdatedAt()
         );

--- a/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
@@ -13,8 +13,9 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
 
     @Query("SELECT n.email FROM Newsletter n WHERE " +
             "(:postType = 'SEMINAR_NOTICE' OR " +
-            "(n.isSeminarContentUpdated = true AND :postType = 'SEMINAR_SUMMARY') OR " +
-            "(n.isStudyUpdated = true AND :postType = 'STUDY') OR " +
-            "(n.isProjectUpdated = true AND :postType = 'PROJECT'))")
+            "(n.seminarContentNotice = true AND :postType = 'SEMINAR_SUMMARY') OR " +
+            "(n.studyNotice = true AND :postType = 'STUDY') OR " +
+            "(n.mentoringNotice = true AND :postType = 'MENTORING') OR " +
+            "(n.projectNotice = true AND :postType = 'PROJECT'))")
     List<String> findSubscriberEmails(@Param("postType") String postType);
 }

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/MentoringNoticeEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/MentoringNoticeEmailDeliveryStrategy.java
@@ -1,0 +1,54 @@
+package com.example.demo.domain.newsletter.strategy;
+
+import com.example.demo.domain.recruitment_board.domain.dto.vo.RecruitmentBoardType;
+import com.example.demo.domain.recruitment_board.domain.entity.RecruitmentBoard;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MentoringNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy {
+    private String type;
+    private String topicTag;
+    private String title;
+    private String author;
+    private String link;
+
+    @Override
+    public String getTemplateName() {
+        return "mentoring_notice";
+    }
+
+    @Override
+    public Map<String, Object> getVariables() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("type", type);
+        variables.put("topicTag", topicTag);
+        variables.put("title", title);
+        variables.put("author", author);
+        variables.put("link", link);
+        return variables;
+    }
+
+    @Override
+    public String getSubject() {
+        return "[야밤의금오톡] '멘토링 공고' 새 글 알림";
+    }
+
+    public static MentoringNoticeEmailDeliveryStrategy create(RecruitmentBoard recruitmentBoard) {
+        if (!recruitmentBoard.getType().equals(RecruitmentBoardType.MENTORING)) {
+            throw new IllegalArgumentException("멘토링에 대한 이메일 알림만 허용합니다.");
+        }
+        return new MentoringNoticeEmailDeliveryStrategy(
+                recruitmentBoard.getType().name(),
+                recruitmentBoard.getTag().name(),
+                recruitmentBoard.getTitle(),
+                recruitmentBoard.getUser().getNickname(),
+                "https://프론트도메인/~" // TODO. 수정 필요
+        );
+    }
+}

--- a/src/main/resources/templates/mentoring_notice.html
+++ b/src/main/resources/templates/mentoring_notice.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>[야밤의금오톡] '멘토링 공고' 새 글 알림</title>
+</head>
+<body>
+<p>안녕하세요, 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+
+<br>
+
+<p>
+    새로운 <strong th:text="${type}">멘토링 타입</strong> 그룹을 모집하는 게시글이 게시되었습니다.<br />
+    <strong th:text="${topicTag}">멘토링 주제 태그</strong>에 관심이 있는 분들은 아래 게시글을 통해 자세한 내용을 확인해주시기 바랍니다.
+</p>
+
+<ul>
+    <li>
+        <h3>멘토링 제목 : <span th:text="${title}">게시글 제목</span></h3>
+    </li>
+    <li>
+        <h3>작성자 : <span th:text="${author}">작성자</span></h3>
+    </li>
+    <li>
+        <h3>게시글 바로가기 : <a th:href="${link}">게시글 링크</a></h3>
+    </li>
+</ul>
+
+<p>
+    멘토링에 참여하여 함께 학습하고 성장하고자 하는 여러분들의 많은 관심
+    부탁드립니다.
+</p>
+
+<p>
+    추가 문의사항이 있으신 분들은 게시글 아래 댓글로 문의해주시면
+    감사하겠습니다.
+</p>
+
+<p>감사합니다.</p>
+
+<br>
+
+<p>[야밤의 금오톡 기술 블로그팀]</p>
+</body>
+</html>


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항
- newletter 필드에 멘토링 알림 필드 추가
- 멘토링 알림 폼 및 관련 전략 설정

### ❓ 리뷰 포인트
<!-- ex) query가 너무 많이 나가는 것 같아요 -->
<!-- ex) service 로직 너무 뚱뚱해요 -->
<!-- ex) 테스트 어떤가요. -->
### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
