### PR TITLE
뉴스레터 전송 관련 작업 및 ADMIN 기능 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,8 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'  // 최신 버전을 사용하려면 2.2.x로 유지
 
-
+    // Jsoup
+    implementation 'org.jsoup:jsoup:1.18.1'
 
 }
 

--- a/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterAdminController.java
+++ b/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterAdminController.java
@@ -1,0 +1,46 @@
+package com.example.demo.domain.newsletter.controller;
+
+import com.example.demo.domain.newsletter.domain.dto.request.EmailNoticeRequest;
+import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
+import com.example.demo.domain.newsletter.domain.dto.response.SeminarNoticeBasicForm;
+import com.example.demo.domain.newsletter.service.NewsletterAdminService;
+import com.example.demo.global.aop.AssignUserId;
+import com.example.demo.global.base.dto.ResponseBody;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.demo.global.base.dto.ResponseUtil.createSuccessResponse;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/admin/newsletters")
+@PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
+public class NewsletterAdminController {
+
+    private final NewsletterAdminService newsletterAdminService;
+
+    /**
+     * html 폼에 따른 세미나 공지사항 전송 api
+     * @param request subject, htmlContent
+     */
+    @PostMapping
+    public ResponseEntity<ResponseBody<Void>> sendNoticeByEmail(@Valid @RequestBody EmailNoticeRequest request) {
+        request.validateHtmlContent();
+        newsletterAdminService.sendNoticeByEmail(request.subject(), request.htmlContent());
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    /**
+     * 세미나 공지사항 기본 폼 제공 api
+     */
+    @GetMapping("/seminar-notice-basicFrom")
+    public ResponseEntity<ResponseBody<SeminarNoticeBasicForm>> getSeminarNoticeBasicForm() {
+        return ResponseEntity.ok(createSuccessResponse(newsletterAdminService.getSeminarNoticeBasicForm()));
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
+++ b/src/main/java/com/example/demo/domain/newsletter/controller/NewsletterController.java
@@ -1,19 +1,36 @@
 package com.example.demo.domain.newsletter.controller;
 
+import com.example.demo.domain.board.domain.dto.vo.Status;
+import com.example.demo.domain.board.domain.entity.Board;
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateEmailRequest;
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateNotifyRequest;
 import com.example.demo.domain.newsletter.domain.dto.response.NewsletterInfo;
+import com.example.demo.domain.newsletter.event.EmailNotificationEvent;
 import com.example.demo.domain.newsletter.service.NewsletterService;
+import com.example.demo.domain.newsletter.strategy.*;
+import com.example.demo.domain.recruitment_board.domain.dto.vo.BoardType;
+import com.example.demo.domain.recruitment_board.domain.dto.vo.RecruitmentBoardTag;
+import com.example.demo.domain.recruitment_board.domain.dto.vo.RecruitmentBoardType;
+import com.example.demo.domain.recruitment_board.domain.entity.RecruitmentBoard;
+import com.example.demo.domain.user.domain.User;
+import com.example.demo.domain.user.domain.vo.Role;
 import com.example.demo.global.aop.AssignUserId;
 import com.example.demo.global.base.dto.ResponseBody;
+import com.example.demo.global.oauth.user.OAuth2Provider;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 import static com.example.demo.global.base.dto.ResponseUtil.createSuccessResponse;
+import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
 @RequiredArgsConstructor
 @RestController
@@ -22,45 +39,123 @@ public class NewsletterController {
 
     private final NewsletterService newsletterService;
 
-    @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PostMapping("/subscribe")
-    public ResponseEntity<ResponseBody<Void>> subscribe(Long userId,
-                                                        @RequestBody @Valid NewsletterSubscribeRequest request) {
-        newsletterService.subscribe(userId, request);
+    public ResponseEntity<ResponseBody<Void>> subscribe(@RequestBody @Valid NewsletterSubscribeRequest request) {
+        newsletterService.subscribe(request);
         return ResponseEntity.ok(createSuccessResponse());
     }
 
-    @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
-    @GetMapping ("/subscribe")
-    public ResponseEntity<ResponseBody<NewsletterInfo>> getNewsletterInfo(Long userId) {
-        return ResponseEntity.ok(createSuccessResponse(newsletterService.getNewsletterInfo(userId)));
-    }
+//    @AssignUserId
+//    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
+//    @GetMapping ("/subscribe")
+//    public ResponseEntity<ResponseBody<NewsletterInfo>> getNewsletterInfo(Long userId) {
+//        return ResponseEntity.ok(createSuccessResponse(newsletterService.getNewsletterInfo(userId)));
+//    }
 
-    @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
-    @PatchMapping("/subscribe/email")
-    public ResponseEntity<ResponseBody<Void>> updateNewsletterEmail(Long userId,
-                                                                    @RequestBody @Valid NewsletterUpdateEmailRequest request) {
-        newsletterService.updateNewsletterEmail(userId, request);
+//    @PatchMapping("/subscribe/email")
+//    public ResponseEntity<ResponseBody<Void>> updateNewsletterEmail(@RequestBody @Valid NewsletterUpdateEmailRequest request) {
+//        newsletterService.updateNewsletterEmail(userId, request);
+//        return ResponseEntity.ok(createSuccessResponse());
+//    }
+
+    @PatchMapping("/subscribe")
+    public ResponseEntity<ResponseBody<Void>> updateNewsletterNotify(@RequestParam @Pattern(regexp = EMAIL_REGEXP, message = "이메일 정규식을 맞춰주세요.") String email,
+                                                                     @RequestBody @Valid NewsletterUpdateNotifyRequest request) {
+        newsletterService.updateNewsletterNotify(email, request);
         return ResponseEntity.ok(createSuccessResponse());
     }
 
-    @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
-    @PatchMapping("/subscribe/notify")
-    public ResponseEntity<ResponseBody<Void>> updateNewsletterNotify(Long userId,
-                                                                   @RequestBody @Valid NewsletterUpdateNotifyRequest request) {
-        newsletterService.updateNewsletterNotify(userId, request);
-        return ResponseEntity.ok(createSuccessResponse());
-    }
-
-    @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @DeleteMapping("/subscribe")
-    public ResponseEntity<ResponseBody<Void>> deleteNewsletterInfo(Long userId) {
-        newsletterService.deleteNewsletterInfo(userId);
+    public ResponseEntity<ResponseBody<Void>> deleteNewsletterInfo(@RequestParam @Pattern(regexp = EMAIL_REGEXP, message = "이메일 정규식을 맞춰주세요.") String email) {
+        newsletterService.deleteNewsletterInfo(email);
         return ResponseEntity.ok(createSuccessResponse());
     }
+
+    // TODO. 이메일 테스트용 추후 삭제
+//    private final ApplicationEventPublisher eventPublisher;
+//    @Transactional
+//    @GetMapping ("/test")
+//    public ResponseEntity<ResponseBody<Void>> test() {
+//        User user = User.builder()
+//                .provider(OAuth2Provider.GOOGLE) // OAuth2Provider의 실제 값을 설정
+//                .providerId("provider-id-example") // 실제 providerId로 변경
+//                .nickname("테스트 닉네임 입니다") // 사용자 닉네임 설정
+//                .role(Role.ROLE_ACTIVE_USER) // Role을 적절히 설정
+//                .build();
+//
+//        Board board = new Board(
+//                "세미나 제목",           // title
+//                "세미나 내용",           // content
+//                user,                   // user
+//                com.example.demo.domain.board.domain.dto.vo.BoardType.SEMINAR,                    // tag
+//                Status.DRAFT,                 // status
+//                "https://example.com/image.jpg" // headImageUrl
+//        );
+//
+//        RecruitmentBoard recruitmentBoard1 = RecruitmentBoard.builder()
+//                .title("멘토링 제목입니다 테스트")
+//                .summary("멘토링 요약 예시")
+//                .content("멘토링 내용 예시")
+//                .type(RecruitmentBoardType.MENTORING)
+//                .tag(RecruitmentBoardTag.BACKEND) // 실제 태그로 변경
+//                .status(Status.DRAFT) // 적절한 상태로 변경
+//                .recruitmentTarget("멘토링 대상 예시")
+//                .recruitmentNum("5") // 모집 인원 수
+//                .recruitmentDeadline(LocalDateTime.now().plusDays(7)) // 마감일 예시
+//                .activityStart(LocalDateTime.now().plusDays(1)) // 활동 시작일 예시
+//                .activityFinish(LocalDateTime.now().plusDays(15)) // 활동 종료일 예시
+//                .activityCycle("주간") // 활동 주기 예시
+//                .user(user) // 실제 User 객체로 변경
+//                .build();
+//
+//        RecruitmentBoard recruitmentBoard2 = RecruitmentBoard.builder()
+//                .title("멘토링 제목입니다 테스트")
+//                .summary("멘토링 요약 예시")
+//                .content("멘토링 내용 예시")
+//                .type(RecruitmentBoardType.PROJECT)
+//                .tag(RecruitmentBoardTag.BACKEND) // 실제 태그로 변경
+//                .status(Status.DRAFT) // 적절한 상태로 변경
+//                .recruitmentTarget("멘토링 대상 예시")
+//                .recruitmentNum("5") // 모집 인원 수
+//                .recruitmentDeadline(LocalDateTime.now().plusDays(7)) // 마감일 예시
+//                .activityStart(LocalDateTime.now().plusDays(1)) // 활동 시작일 예시
+//                .activityFinish(LocalDateTime.now().plusDays(15)) // 활동 종료일 예시
+//                .activityCycle("주간") // 활동 주기 예시
+//                .user(user) // 실제 User 객체로 변경
+//                .build();
+//
+//        RecruitmentBoard recruitmentBoard3 = RecruitmentBoard.builder()
+//                .title("멘토링 제목입니다 테스트")
+//                .summary("멘토링 요약 예시")
+//                .content("멘토링 내용 예시")
+//                .type(RecruitmentBoardType.STUDY)
+//                .tag(RecruitmentBoardTag.BACKEND) // 실제 태그로 변경
+//                .status(Status.DRAFT) // 적절한 상태로 변경
+//                .recruitmentTarget("멘토링 대상 예시")
+//                .recruitmentNum("5") // 모집 인원 수
+//                .recruitmentDeadline(LocalDateTime.now().plusDays(7)) // 마감일 예시
+//                .activityStart(LocalDateTime.now().plusDays(1)) // 활동 시작일 예시
+//                .activityFinish(LocalDateTime.now().plusDays(15)) // 활동 종료일 예시
+//                .activityCycle("주간") // 활동 주기 예시
+//                .user(user) // 실제 User 객체로 변경
+//                .build();
+//
+//        eventPublisher.publishEvent(
+//                EmailNotificationEvent.create(
+//                        BoardType.MENTORING,
+//                        MentoringNoticeEmailDeliveryStrategy.create(recruitmentBoard1)));
+//        eventPublisher.publishEvent(
+//                EmailNotificationEvent.create(
+//                        BoardType.PROJECT,
+//                        ProjectNoticeEmailDeliveryStrategy.create(recruitmentBoard2)));
+//        eventPublisher.publishEvent(
+//                EmailNotificationEvent.create(
+//                        BoardType.SEMINAR_SUMMARY,
+//                        SeminarSummaryEmailDeliveryStrategy.create(board)));
+//        eventPublisher.publishEvent(
+//                EmailNotificationEvent.create(
+//                        BoardType.STUDY,
+//                        StudyNoticeEmailDeliveryStrategy.create(recruitmentBoard3)));
+//        return ResponseEntity.ok(createSuccessResponse());
+//    }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/Newsletter.java
@@ -1,17 +1,15 @@
 package com.example.demo.domain.newsletter.domain;
 
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
-import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateEmailRequest;
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateNotifyRequest;
 import com.example.demo.global.base.domain.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -52,11 +50,8 @@ public class Newsletter extends BaseEntity {
                 .build();
     }
 
-    public void updateNewsletterEmail(@Valid NewsletterUpdateEmailRequest request) {
+    public void updateNewsletter(NewsletterUpdateNotifyRequest request) {
         this.email = request.email();
-    }
-
-    public void updateNewsletterNotify(@Valid NewsletterUpdateNotifyRequest request) {
         this.seminarContentNotice = request.seminarContentNotice();
         this.studyNotice = request.studyNotice();
         this.projectNotice = request.projectNotice();

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/EmailNoticeRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/EmailNoticeRequest.java
@@ -1,0 +1,23 @@
+package com.example.demo.domain.newsletter.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+
+public record EmailNoticeRequest(
+        @NotBlank(message = "제목은 필수입니다.") String subject,
+        @NotBlank(message = "HTML 내용은 필수입니다.") String htmlContent
+) {
+    public void validateHtmlContent() {
+        try {
+            // TODO. 정말 최소한의 검사. 좀 더 좋은 방법이 존재할까?
+            Document document = Jsoup.parse(htmlContent, "", Parser.htmlParser());
+            if (document.body().childrenSize() == 0) { // 본문이 존재하는지 체크
+                throw new IllegalArgumentException("HTML 내용이 유효하지 않습니다. 본문이 없습니다.");
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("HTML 내용이 유효하지 않습니다: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateNotifyRequest.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/request/NewsletterUpdateNotifyRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Pattern;
 import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 
 public record NewsletterUpdateNotifyRequest(
+        @Pattern(regexp = EMAIL_REGEXP, message = "이메일 정규식을 맞춰주세요.") String email,
         @NotNull(message = "세미나 내용정리 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean seminarContentNotice,
         @NotNull(message = "스터디 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean studyNotice,
         @NotNull(message = "프로젝트 새 글 업데이트 알림 여/부를 선택해주세요.") Boolean projectNotice,

--- a/src/main/java/com/example/demo/domain/newsletter/domain/dto/response/SeminarNoticeBasicForm.java
+++ b/src/main/java/com/example/demo/domain/newsletter/domain/dto/response/SeminarNoticeBasicForm.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.newsletter.domain.dto.response;
+
+public record SeminarNoticeBasicForm(
+        String seminarNoticeBasicFrom
+) {
+}

--- a/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/example/demo/domain/newsletter/repository/NewsletterRepository.java
@@ -2,11 +2,13 @@ package com.example.demo.domain.newsletter.repository;
 
 import com.example.demo.domain.newsletter.domain.Newsletter;
 import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
     boolean existsByEmail(String email);
@@ -18,4 +20,6 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
             "(n.mentoringNotice = true AND :postType = 'MENTORING') OR " +
             "(n.projectNotice = true AND :postType = 'PROJECT'))")
     List<String> findSubscriberEmails(@Param("postType") String postType);
+
+    Optional<Newsletter> findByEmail(String email);
 }

--- a/src/main/java/com/example/demo/domain/newsletter/service/NewsletterAdminService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/NewsletterAdminService.java
@@ -1,0 +1,40 @@
+package com.example.demo.domain.newsletter.service;
+
+import com.example.demo.domain.newsletter.domain.dto.response.SeminarNoticeBasicForm;
+import com.example.demo.domain.newsletter.event.EmailNotificationEvent;
+import com.example.demo.domain.newsletter.repository.NewsletterRepository;
+import com.example.demo.domain.newsletter.strategy.ByPassEmailDeliveryStrategy;
+import com.example.demo.domain.recruitment_board.domain.dto.vo.BoardType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class NewsletterAdminService {
+
+    private final NewsletterRepository newsletterRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final TemplateEngine templateEngine;
+
+    public void sendNoticeByEmail(String subject, String htmlContent) {
+        eventPublisher.publishEvent(
+                EmailNotificationEvent.create(
+                        BoardType.SEMINAR_NOTICE,
+                        ByPassEmailDeliveryStrategy.create(subject, htmlContent)));
+    }
+
+    public SeminarNoticeBasicForm getSeminarNoticeBasicForm() {
+        ByPassEmailDeliveryStrategy byPassEmailDeliveryStrategy = new ByPassEmailDeliveryStrategy();
+        Context context = new Context();
+        context.setVariables(byPassEmailDeliveryStrategy.getVariables());
+        String html = templateEngine.process(byPassEmailDeliveryStrategy.getTemplateName(), context);
+        return new SeminarNoticeBasicForm(html);
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
@@ -2,14 +2,11 @@ package com.example.demo.domain.newsletter.service;
 
 import com.example.demo.domain.newsletter.domain.Newsletter;
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterSubscribeRequest;
-import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateEmailRequest;
 import com.example.demo.domain.newsletter.domain.dto.request.NewsletterUpdateNotifyRequest;
-import com.example.demo.domain.newsletter.domain.dto.response.NewsletterInfo;
 import com.example.demo.domain.newsletter.repository.NewsletterRepository;
-import com.example.demo.domain.user.domain.User;
 import com.example.demo.domain.user.service.UserService;
 import com.example.demo.global.base.exception.ServiceException;
-import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,10 +23,9 @@ public class NewsletterService {
     private final NewsletterRepository newsletterRepository;
 
     @Transactional
-    public void subscribe(Long userId, @Valid NewsletterSubscribeRequest request) {
-        User user = userService.validateUser(userId);
+    public void subscribe(NewsletterSubscribeRequest request) {
         this.validateSubscribe(request.email());
-        user.mapNewsletter(Newsletter.from(request));
+        newsletterRepository.save(Newsletter.from(request));
     }
     
     public void validateSubscribe(String email) {
@@ -38,33 +34,33 @@ public class NewsletterService {
         }
     }
 
-    public NewsletterInfo getNewsletterInfo(Long userId) {
-        User user = userService.validateUser(userId);
-        if (user.getNewsletter() == null) {
-            throw new ServiceException(SUBSCRIBE_NOT_FOUND);
-        }
-        return NewsletterInfo.from(user.getNewsletter());
+//    public NewsletterInfo getNewsletterInfo(Long userId) {
+//        User user = userService.validateUser(userId);
+//        if (!user.hasNewsletter()) {
+//            throw new ServiceException(SUBSCRIBE_NOT_FOUND);
+//        }
+//        return NewsletterInfo.from(user.getNewsletter());
+//    }
+
+//    @Transactional
+//    public void updateNewsletterEmail(NewsletterUpdateEmailRequest request) {
+//        this.validateSubscribe(request.email());
+//        Newsletter newsletter = newsletterRepository.findByEmail(request.email())
+//                .orElseThrow(() -> new ServiceException(SUBSCRIBE_NOT_FOUND));
+//        newsletter.updateNewsletter(request);
+//    }
+
+    @Transactional
+    public void updateNewsletterNotify(String email, NewsletterUpdateNotifyRequest request) {
+        Newsletter newsletter = newsletterRepository.findByEmail(email)
+                .orElseThrow(() -> new ServiceException(SUBSCRIBE_NOT_FOUND));
+        newsletter.updateNewsletter(request);
     }
 
     @Transactional
-    public void updateNewsletterEmail(Long userId, @Valid NewsletterUpdateEmailRequest request) {
-        User user = userService.validateUser(userId);
-        this.validateSubscribe(request.email());
-        user.getNewsletter().updateNewsletterEmail(request);
-    }
-
-    @Transactional
-    public void updateNewsletterNotify(Long userId, @Valid NewsletterUpdateNotifyRequest request) {
-        User user = userService.validateUser(userId);
-        user.getNewsletter().updateNewsletterNotify(request);
-    }
-
-    @Transactional
-    public void deleteNewsletterInfo(Long userId) {
-        User user = userService.validateUser(userId);
-        Newsletter newsletter = user.getNewsletter();
-        if (newsletter != null) {
-            user.mapNewsletter(null);
-        }
+    public void deleteNewsletterInfo(String email) {
+        Newsletter newsletter = newsletterRepository.findByEmail(email)
+                .orElseThrow(() -> new ServiceException(SUBSCRIBE_NOT_FOUND));
+        newsletterRepository.delete(newsletter);
     }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/BaseEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/BaseEmailDeliveryStrategy.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.newsletter.strategy;
+
+public abstract class BaseEmailDeliveryStrategy implements EmailDeliveryStrategy {
+    protected String youtubeUrl = "https://www.youtube.com/@midnight_kumoh_talk";
+    protected String changeSubscribeUrl = "https://FrontUrl/change"; // TODO. 프론트 배포 후 변경 필요
+    protected String cancelSubscribeUrl = "https://FrontUrl/cancel"; // TODO. 프론트 배포 후 변경 필요
+}

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/ByPassEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/ByPassEmailDeliveryStrategy.java
@@ -1,0 +1,35 @@
+package com.example.demo.domain.newsletter.strategy;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ByPassEmailDeliveryStrategy extends BaseEmailDeliveryStrategy {
+    private String subject;
+    private String htmlContent;
+
+    @Override
+    public String getTemplateName() {
+        return "seminar_notice";
+    }
+
+    @Override
+    public Map<String, Object> getVariables() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("youtubeUrl", youtubeUrl);
+        variables.put("changeSubscribeUrl", changeSubscribeUrl);
+        variables.put("cancelSubscribeUrl", cancelSubscribeUrl);
+        return variables;
+    }
+
+    public static ByPassEmailDeliveryStrategy create(String subject, String htmlContent) {
+        return new ByPassEmailDeliveryStrategy(subject, htmlContent);
+    }
+}

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/MentoringNoticeEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/MentoringNoticeEmailDeliveryStrategy.java
@@ -11,12 +11,12 @@ import java.util.Map;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class MentoringNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy {
+public class MentoringNoticeEmailDeliveryStrategy extends BaseEmailDeliveryStrategy {
     private String type;
     private String topicTag;
     private String title;
     private String author;
-    private String link;
+    private String postUrl;
 
     @Override
     public String getTemplateName() {
@@ -30,7 +30,10 @@ public class MentoringNoticeEmailDeliveryStrategy implements EmailDeliveryStrate
         variables.put("topicTag", topicTag);
         variables.put("title", title);
         variables.put("author", author);
-        variables.put("link", link);
+        variables.put("postUrl", postUrl);
+        variables.put("youtubeUrl", youtubeUrl);
+        variables.put("changeSubscribeUrl", changeSubscribeUrl);
+        variables.put("cancelSubscribeUrl", cancelSubscribeUrl);
         return variables;
     }
 

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/ProjectNoticeEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/ProjectNoticeEmailDeliveryStrategy.java
@@ -11,12 +11,12 @@ import java.util.Map;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ProjectNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy {
+public class ProjectNoticeEmailDeliveryStrategy extends BaseEmailDeliveryStrategy {
     private String type;
     private String tag;
     private String title;
     private String author;
-    private String link;
+    private String postUrl;
 
     @Override
     public String getTemplateName() {
@@ -30,7 +30,10 @@ public class ProjectNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy
         variables.put("tag", tag);
         variables.put("title", title);
         variables.put("author", author);
-        variables.put("link", link);
+        variables.put("postUrl", postUrl);
+        variables.put("youtubeUrl", youtubeUrl);
+        variables.put("changeSubscribeUrl", changeSubscribeUrl);
+        variables.put("cancelSubscribeUrl", cancelSubscribeUrl);
         return variables;
     }
 
@@ -41,7 +44,7 @@ public class ProjectNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy
 
     public static ProjectNoticeEmailDeliveryStrategy create(RecruitmentBoard recruitmentBoard) {
         if (!recruitmentBoard.getType().equals(RecruitmentBoardType.PROJECT)) {
-            throw new IllegalArgumentException("스터디에 대한 이메일 알림만 허용합니다.");
+            throw new IllegalArgumentException("프로젝트에 대한 이메일 알림만 허용합니다.");
         }
         return new ProjectNoticeEmailDeliveryStrategy(
                 recruitmentBoard.getType().name(),

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/SeminarSummaryEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/SeminarSummaryEmailDeliveryStrategy.java
@@ -10,15 +10,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class SeminarSummaryEmailDeliveryStrategy implements EmailDeliveryStrategy {
+@AllArgsConstructor
+public class SeminarSummaryEmailDeliveryStrategy extends BaseEmailDeliveryStrategy {
     private String title;
     private String author;
-    private String link;
+    private String postUrl;
 
     @Override
     public String getTemplateName() {
-        return "seminar_notice";
+        return "seminar_summary";
     }
 
     @Override
@@ -26,7 +26,10 @@ public class SeminarSummaryEmailDeliveryStrategy implements EmailDeliveryStrateg
         Map<String, Object> variables = new HashMap<>();
         variables.put("title", title);
         variables.put("author", author);
-        variables.put("link", link);
+        variables.put("postUrl", postUrl);
+        variables.put("youtubeUrl", youtubeUrl);
+        variables.put("changeSubscribeUrl", changeSubscribeUrl);
+        variables.put("cancelSubscribeUrl", cancelSubscribeUrl);
         return variables;
     }
 
@@ -39,10 +42,10 @@ public class SeminarSummaryEmailDeliveryStrategy implements EmailDeliveryStrateg
         if (!board.getBoardType().equals(BoardType.SEMINAR)) {
             throw new IllegalArgumentException("세미나 내용 정리에 대한 이메일 알림만 허용합니다.");
         }
-        return new SeminarSummaryEmailDeliveryStrategy(
+        return new SeminarSummaryEmailDeliveryStrategy(// TODO. 프론트 배포 후 수정 필요
                 board.getTitle(),
                 board.getUser().getNickname(),
-                "https://프론트도메인/~" // TODO. 수정 필요
+                "https://프론트도메인/~"
         );
     }
 }

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/StudyNoticeEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/StudyNoticeEmailDeliveryStrategy.java
@@ -11,12 +11,12 @@ import java.util.Map;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class StudyNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy {
+public class StudyNoticeEmailDeliveryStrategy extends BaseEmailDeliveryStrategy {
     private String type;
     private String tag;
     private String title;
     private String author;
-    private String link;
+    private String postUrl;
 
     @Override
     public String getTemplateName() {
@@ -30,7 +30,10 @@ public class StudyNoticeEmailDeliveryStrategy implements EmailDeliveryStrategy {
         variables.put("tag", tag);
         variables.put("title", title);
         variables.put("author", author);
-        variables.put("link", link);
+        variables.put("postUrl", postUrl);
+        variables.put("youtubeUrl", youtubeUrl);
+        variables.put("changeSubscribeUrl", changeSubscribeUrl);
+        variables.put("cancelSubscribeUrl", cancelSubscribeUrl);
         return variables;
     }
 

--- a/src/main/java/com/example/demo/domain/report/controller/ReportAdminController.java
+++ b/src/main/java/com/example/demo/domain/report/controller/ReportAdminController.java
@@ -1,0 +1,32 @@
+package com.example.demo.domain.report.controller;
+
+import com.example.demo.domain.report.domain.dto.ReportResponse;
+import com.example.demo.domain.report.service.ReportService;
+import com.example.demo.global.base.dto.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.demo.global.base.dto.ResponseUtil.createSuccessResponse;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+public class ReportAdminController {
+
+    private final ReportService reportService;
+
+    /**
+     * 관리자 기능 - 모든 신고목록 보기
+     */
+    @GetMapping
+    public ResponseEntity<ResponseBody<Page<ReportResponse>>> getAllReport(
+            @PageableDefault(page=0, size=10,sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(createSuccessResponse(reportService.getAllReport(pageable)));
+    }
+}

--- a/src/main/java/com/example/demo/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/demo/domain/report/repository/ReportRepository.java
@@ -8,6 +8,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
-
-    Page<Report> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/example/demo/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/demo/domain/report/service/ReportService.java
@@ -13,7 +13,6 @@ import com.example.demo.global.base.exception.ErrorCode;
 import com.example.demo.global.base.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,9 +42,7 @@ public class ReportService {
         discordReportClient.sendReport(DiscordMessage.createCommentReportMessage(user, comment));
     }
 
-    public Page<ReportResponse> findAll(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<Report> reportPage = reportRepository.findAllByOrderByCreatedAtDesc(pageable);
-        return reportPage.map(ReportResponse::from);
+    public Page<ReportResponse> getAllReport(Pageable pageable) {
+        return reportRepository.findAll(pageable).map(ReportResponse::from);
     }
 }

--- a/src/main/java/com/example/demo/domain/user/controller/UserAdminController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserAdminController.java
@@ -1,0 +1,46 @@
+package com.example.demo.domain.user.controller;
+
+import com.example.demo.domain.user.domain.dto.request.UpdateUserInfoRequest;
+import com.example.demo.domain.user.domain.dto.response.UserInfo;
+import com.example.demo.domain.user.service.UserAdminService;
+import com.example.demo.global.base.dto.ResponseBody;
+import com.example.demo.global.base.dto.page.GlobalPageResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.demo.global.base.dto.ResponseUtil.createSuccessResponse;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
+public class UserAdminController {
+
+    private final UserAdminService userAdminService;
+
+    @GetMapping
+    public ResponseEntity<ResponseBody<GlobalPageResponse<UserInfo>>> getAllUsers (
+            @PageableDefault(page=0, size=10,sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(createSuccessResponse(userAdminService.getAllUsers(pageable)));
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity<ResponseBody<Void>> updateUserInfo (@PathVariable Long userId, @Valid @RequestBody UpdateUserInfoRequest request) {
+        userAdminService.updateUserInfo(userId, request);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<ResponseBody<Void>> deleteUser (@PathVariable Long userId) {
+        userAdminService.deleteUser(userId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/controller/UserFileController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserFileController.java
@@ -36,4 +36,12 @@ public class UserFileController {
         userFileService.changeProfileUrl(userId, request);
         return ResponseEntity.ok(createSuccessResponse());
     }
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
+    @DeleteMapping("/profile")
+    public ResponseEntity<ResponseBody<Void>> deleteProfileImage(Long userId) {
+        userFileService.deleteProfileImage(userId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
 }

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -5,6 +5,7 @@ import com.example.demo.domain.board.domain.entity.Board;
 import com.example.demo.domain.board.domain.entity.Like;
 import com.example.demo.domain.newsletter.domain.Newsletter;
 import com.example.demo.domain.seminar_application.domain.SeminarApplication;
+import com.example.demo.domain.user.domain.dto.request.UpdateUserInfoRequest;
 import com.example.demo.domain.user.domain.vo.Role;
 import com.example.demo.domain.user_addtional_info.domain.UserAdditionalInfo;
 import com.example.demo.global.base.domain.BaseEntity;
@@ -53,9 +54,10 @@ public class User extends BaseEntity {
     @JoinColumn(name = "user_additional_info_id")
     private UserAdditionalInfo userAdditionalInfo;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "news_letter_id")
-    private Newsletter newsletter;
+    // TODO. 추후 user 와 newsletter 연동이 확정되면 추가
+//    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+//    @JoinColumn(name = "news_letter_id")
+//    private Newsletter newsletter;
 
     @OneToMany(mappedBy = "user")
     private List<Board> boards = new ArrayList<>();
@@ -78,10 +80,7 @@ public class User extends BaseEntity {
     }
 
     public void setInitialInfo(String nickname, String name, String defaultImageUrl) {
-        this.nickname = nickname;
-        this.name = name;
-        this.profileImageUrl = defaultImageUrl;
-        this.role = Role.ROLE_USER;
+
     }
 
     public void updateNickname(String nickname) {
@@ -92,9 +91,9 @@ public class User extends BaseEntity {
         this.userAdditionalInfo = userAdditionalInfo;
     }
 
-    public void mapNewsletter(Newsletter newsletter) {
-        this.newsletter = newsletter;
-    }
+//    public void mapNewsletter(Newsletter newsletter) {
+//        this.newsletter = newsletter;
+//    }
 
     public void addSeminarApplications(SeminarApplication seminarApplication) {
         this.seminarApplications.add(seminarApplication);
@@ -110,5 +109,24 @@ public class User extends BaseEntity {
 
     public void changeProfileUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public Boolean isAdmin() {
+        return Role.ROLE_ADMIN.equals(this.role);
+    }
+
+    public void updateUserInfo(UpdateUserInfoRequest request) {
+        this.nickname = request.nickname();
+        this.name = request.name();
+        this.profileImageUrl = request.profileImageUrl();
+        this.role = request.role();
+    }
+
+//    public boolean hasNewsletter() {
+//        return this.newsletter != null;
+//    }
+
+    public void setDefaultProfileUrl(String defaultImageUrl) {
+        this.profileImageUrl = defaultImageUrl;
     }
 }

--- a/src/main/java/com/example/demo/domain/user/domain/dto/request/UpdateUserInfoRequest.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/request/UpdateUserInfoRequest.java
@@ -1,0 +1,17 @@
+package com.example.demo.domain.user.domain.dto.request;
+
+import com.example.demo.domain.user.domain.vo.Role;
+import com.example.demo.global.aop.valid.ValidEnum;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+import static com.example.demo.global.regex.S3UrlRegex.S3_PROFILE_FILE_URL;
+import static com.example.demo.global.regex.UserRegex.NICKNAME_REGEXP;
+
+public record UpdateUserInfoRequest(
+        @Pattern(regexp = NICKNAME_REGEXP, message = "닉네임 정규식을 맞춰주세요.") String nickname,
+        @NotBlank(message = "이름은 빈값일 수 없습니다.") String name,
+        @Pattern(regexp = S3_PROFILE_FILE_URL) String profileImageUrl,
+        @ValidEnum(enumClass = Role.class) Role role
+) {
+}

--- a/src/main/java/com/example/demo/domain/user/domain/dto/response/UserInfo.java
+++ b/src/main/java/com/example/demo/domain/user/domain/dto/response/UserInfo.java
@@ -12,7 +12,7 @@ public record UserInfo(
         OAuth2Provider provider,
         String nickname,
         String name,
-        String profileImage,
+        String profileImageUrl,
         Role role,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime createdAt,

--- a/src/main/java/com/example/demo/domain/user/service/UserAdminService.java
+++ b/src/main/java/com/example/demo/domain/user/service/UserAdminService.java
@@ -1,0 +1,52 @@
+package com.example.demo.domain.user.service;
+
+import com.example.demo.domain.user.domain.User;
+import com.example.demo.domain.user.domain.dto.request.UpdateUserInfoRequest;
+import com.example.demo.domain.user.domain.dto.response.UserInfo;
+import com.example.demo.domain.user.repository.UserRepository;
+import com.example.demo.global.base.dto.page.GlobalPageResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class UserAdminService {
+
+    private final UserRepository userRepository;
+    private final UserService userService;
+
+    public Boolean isAdmin(Long userId) {
+        Optional<User> userOptional = userRepository.findById(userId);
+
+        if (userOptional.isPresent()) {
+            User user = userOptional.get();
+            return user.isAdmin();
+        }
+
+        return false;
+    }
+
+    public GlobalPageResponse<UserInfo> getAllUsers(Pageable pageable) {
+        Page<UserInfo> userInfoPage = userRepository.findAll(pageable).map(UserInfo::from);
+        return GlobalPageResponse.create(userInfoPage);
+    }
+
+    @Transactional
+    public void updateUserInfo(Long userId, UpdateUserInfoRequest request) {
+        User user = userService.validateUser(userId);
+        userService.checkNicknameDuplicate(request.nickname());
+        user.updateUserInfo(request);
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        userRepository.deleteById(userId);
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/service/UserFileService.java
+++ b/src/main/java/com/example/demo/domain/user/service/UserFileService.java
@@ -30,4 +30,10 @@ public class UserFileService {
         User user = userService.validateUser(userId);
         user.changeProfileUrl(request.url());
     }
+
+    @Transactional
+    public void deleteProfileImage(Long userId) {
+        User user = userService.validateUser(userId);
+        user.setDefaultProfileUrl(s3UrlUtil.getDefaultImageUrl());
+    }
 }

--- a/src/main/java/com/example/demo/global/base/dto/page/GlobalPageResponse.java
+++ b/src/main/java/com/example/demo/global/base/dto/page/GlobalPageResponse.java
@@ -42,4 +42,13 @@ public class GlobalPageResponse<T> {
 			pageDTO.getContent());
 	}
 
+	public static <T> GlobalPageResponse<T> create(
+			Page<T> pageDTO) {
+		return new GlobalPageResponse<>(
+                pageDTO.getNumber() + 1,
+                pageDTO.getSize(),
+                pageDTO.getTotalPages(),
+                pageDTO.getSort().toString(),
+                pageDTO.getContent());
+	}
 }

--- a/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
     // Newsletter
     SUBSCRIBE_EMAIL_CONFLICT(HttpStatus.CONFLICT, "NEWSLETTER_0001", "이미 구독되어있는 이메일입니다."),
     SUBSCRIBE_NOT_FOUND(HttpStatus.NOT_FOUND, "NEWSLETTER_0002", "구독 정보가 존재하지 않습니다."),
+    ALREADY_SUBSCRIBE(HttpStatus.CONFLICT, "NEWSLETTER_0003", "사용자는 이미 구독중입니다."),
 
     // SeminarApplication
     SEMINAR_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "SEMINAR_0001", "해당 세미나 신청폼 정보가 존재하지 않습니다."),

--- a/src/main/java/com/example/demo/global/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/base/exception/GlobalExceptionHandler.java
@@ -77,7 +77,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ResponseBody<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.error("IllegalArgumentException : {}", e.getMessage());
         return ResponseEntity.badRequest()
-                .body(createFailureResponse(ErrorCode.INVALID_INPUT_VALUE));
+                .body(createFailureResponse(ErrorCode.INVALID_INPUT_VALUE, e.getMessage()));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class) // JSON 파싱 예외

--- a/src/main/java/com/example/demo/global/jwt/exception/JwtAccessDeniedException.java
+++ b/src/main/java/com/example/demo/global/jwt/exception/JwtAccessDeniedException.java
@@ -1,0 +1,9 @@
+package com.example.demo.global.jwt.exception;
+
+import com.example.demo.global.base.exception.ErrorCode;
+
+public class JwtAccessDeniedException extends JwtAuthenticationException {
+    public JwtAccessDeniedException() {
+        super(ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/example/demo/global/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/example/demo/global/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
 	public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
-	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect-uri";
 	public static final String MODE_PARAM_COOKIE_NAME = "mode";
 	private static final int COOKIE_EXPIRE_SECONDS = 180;
 

--- a/src/main/resources/templates/mentoring_notice.html
+++ b/src/main/resources/templates/mentoring_notice.html
@@ -6,41 +6,97 @@
     <title>[야밤의금오톡] '멘토링 공고' 새 글 알림</title>
 </head>
 <body>
-<p>안녕하세요, 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+<div style="text-align: center; font-size: 13px; line-height: 2">
+    <img
+            src="https://kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com/email/kumoh-talk-header.png"
+            alt="배너 이미지"
+            width="480"
+            height="140"
+            style="border-radius: 15px"
+    />
 
-<br>
+    <h2 style="text-align: center; margin: 2px">📚 멘토링 새 글 발행</h2>
+    <p>안녕하세요. 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+    <div style="height: 2px"></div>
+    <p>
+        새로운
+        <span
+                th:text="${type}"
+                style="
+            color: #2b4577;
+            background-color: #eaeaea;
+            padding: 0px 4px;
+            border-radius: 4px;
+            display: inline-block;
+          "
+        >멘토링</span
+        >
+        그룹을 모집하는 게시글이 게시되었습니다.
+    </p>
+    <div style="height: 4px"></div>
+    <p>
+        <span
+                th:text="${topicTag}"
+                style="
+            color: #2b4577;
+            background-color: #eaeaea;
+            padding: 0px 4px;
+            border-radius: 4px;
+            display: inline-block;
+          "
+        >멘토링 주제</span
+        >에 관심이 있는 분들은,
+    </p>
+    <div style="height: 4px"></div>
+    <p>아래 게시글을 통해 자세한 내용을 확인해주시기 바랍니다.</p>
 
-<p>
-    새로운 <strong th:text="${type}">멘토링 타입</strong> 그룹을 모집하는 게시글이 게시되었습니다.<br />
-    <strong th:text="${topicTag}">멘토링 주제 태그</strong>에 관심이 있는 분들은 아래 게시글을 통해 자세한 내용을 확인해주시기 바랍니다.
-</p>
+    <ul style="list-style-type: none; padding: 0">
+        <li>
+            <h4 style="margin: 2px">
+                멘토링 주제 : <span th:text="${title}">주제</span>
+            </h4>
+        </li>
+        <li>
+            <h4 style="margin: 2px">
+                작성자 : <span th:text="${author}">작성자</span>
+            </h4>
+        </li>
+        <li>
+            <h4 style="margin: 2px">
+                <a th:href="${postUrl}">게시글 바로가기</a>
+            </h4>
+        </li>
+    </ul>
+    <p>
+        멘토링에 참여하여 함께 학습하고자 하는 여러분들의 많은 관심
+        부탁드립니다.
+    </p>
+    <p>
+        추가 문의사항이 있으신 분들은 게시글 아래 댓글로 문의해주시면
+        감사하겠습니다.
+    </p>
+    <hr style="width: 480px; margin: 15px auto" />
 
-<ul>
-    <li>
-        <h3>멘토링 제목 : <span th:text="${title}">게시글 제목</span></h3>
-    </li>
-    <li>
-        <h3>작성자 : <span th:text="${author}">작성자</span></h3>
-    </li>
-    <li>
-        <h3>게시글 바로가기 : <a th:href="${link}">게시글 링크</a></h3>
-    </li>
-</ul>
-
-<p>
-    멘토링에 참여하여 함께 학습하고 성장하고자 하는 여러분들의 많은 관심
-    부탁드립니다.
-</p>
-
-<p>
-    추가 문의사항이 있으신 분들은 게시글 아래 댓글로 문의해주시면
-    감사하겠습니다.
-</p>
-
-<p>감사합니다.</p>
-
-<br>
-
-<p>[야밤의 금오톡 기술 블로그팀]</p>
+    <img
+            src="https://kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com/email/kumoh-talk-logo.jpeg"
+            alt="로고 이미지"
+            width="40"
+    /><br />
+    <a th:href="${youtubeUrl}" style="line-height: 3.5"
+    >야밤의금오톡 Youtube</a
+    >
+    <br />
+    <a
+            th:href="${changeSubscribeUrl}"
+            style="color: gray; font-size: 10px; text-decoration: none"
+    >구독정보 변경하기</a
+    >
+    <span style="color: gray; padding: 0.3%">|</span>
+    <a
+            th:href="${cancelSubscribeUrl}"
+            style="color: gray; font-size: 10px; text-decoration: none"
+    >구독취소</a
+    >
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/project_team_notice.html
+++ b/src/main/resources/templates/project_team_notice.html
@@ -1,40 +1,101 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>[야밤의금오톡] '프로젝트 팀원 공고' 새 글 알림</title>
 </head>
 <body>
-<p>안녕하세요, 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+<div style="text-align: center; font-size: 13px; line-height: 2">
+    <img
+            src="https://kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com/email/kumoh-talk-header.png"
+            alt="배너 이미지"
+            width="480"
+            height="140"
+            style="border-radius: 15px"
+    />
 
-<p>
-    새로운 <strong th:text="${type}">프로젝트 태그</strong>에 함께할 팀원을 구하는 게시글이 게시되었습니다.<br>
-    <strong th:text="${tag}">개발직군 태그</strong>에 관심이 있거나, 함께 의미 있는 프로젝트를 진행해보고 싶은 분들은 아래 게시글을 통해 자세한 내용을 확인해주시기 바랍니다.
-</p>
+    <h2 style="text-align: center; margin: 2px">📚 프로젝트 새 글 발행</h2>
+    <p>안녕하세요. 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+    <div style="height: 2px"></div>
+    <p>
+        새로운
+        <span
+                th:text="${type}"
+                style="
+            color: #2b4577;
+            background-color: #eaeaea;
+            padding: 0px 4px;
+            border-radius: 4px;
+            display: inline-block;
+          "
+        >프로젝트</span
+        >에 함께할 팀원을 구하는 게시글이 게시되었습니다.
+    </p>
+    <div style="height: 4px"></div>
+    <p>
+        <span
+                th:text="${tag}"
+                style="
+            color: #2b4577;
+            background-color: #eaeaea;
+            padding: 0px 4px;
+            border-radius: 4px;
+            display: inline-block;
+          "
+        >개발직군</span
+        >와 관련된 의미있는 프로젝트를 진행해보고 싶은 분들은,
+    </p>
+    <div style="height: 4px"></div>
+    <p>아래 게시글을 통해 자세한 내용을 확인해주시기 바랍니다.</p>
 
-<ul>
-    <li>
-        <h3>프로젝트 주제 : <span th:text="${title}">게시글 제목</span></h3>
-    </li>
-    <li>
-        <h3>작성자 : <span th:text="${author}">작성자</span></h3>
-    </li>
-    <li>
-        <h3>게시글 바로가기 : <a th:href="${link}">게시글 링크</a></h3>
-    </li>
-</ul>
+    <ul style="list-style-type: none; padding: 0">
+        <li>
+            <h4 style="margin: 2px">
+                프로젝트 주제 : <span th:text="${title}">주제</span>
+            </h4>
+        </li>
+        <li>
+            <h4 style="margin: 2px">
+                작성자 : <span th:text="${author}">작성자</span>
+            </h4>
+        </li>
+        <li>
+            <h4 style="margin: 2px">
+                <a th:href="${postUrl}">게시글 바로가기</a>
+            </h4>
+        </li>
+    </ul>
+    <p>
+        프로젝트에 참여하여 함께 협력하고자 하는 여러분들의 많은 관심
+        부탁드립니다.
+    </p>
+    <p>
+        추가 문의사항이 있으신 분들은 게시글 아래 댓글로 문의해주시면
+        감사하겠습니다.
+    </p>
+    <hr style="width: 480px; margin: 15px auto" />
 
-<p>
-    프로젝트에 참여하여 팀원으로서 함께 협력하고 성장하고자 하는 여러분들의 많은 관심 부탁드립니다.
-</p>
-
-<p>
-    추가 문의사항이 있으신 분들은 게시글 아래 댓글로 문의해주시면 감사하겠습니다.
-</p>
-
-<p>감사합니다.</p>
-
-<p>[야밤의 금오톡 기술 블로그팀]</p>
+    <img
+            src="https://kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com/email/kumoh-talk-logo.jpeg"
+            alt="로고 이미지"
+            width="40"
+    /><br />
+    <a th:href="${youtubeUrl}" style="line-height: 3.5"
+    >야밤의금오톡 Youtube</a
+    >
+    <br />
+    <a
+            th:href="${changeSubscribeUrl}"
+            style="color: gray; font-size: 10px; text-decoration: none"
+    >구독정보 변경하기</a
+    >
+    <span style="color: gray; padding: 0.3%">|</span>
+    <a
+            th:href="${cancelSubscribeUrl}"
+            style="color: gray; font-size: 10px; text-decoration: none"
+    >구독취소</a
+    >
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/seminar_notice.html
+++ b/src/main/resources/templates/seminar_notice.html
@@ -3,39 +3,114 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>[야밤의금오톡] '세미나 발표 정리' 새 글 알림</title>
+    <title>[야밤의금오톡] '세미나' 공지사항 알림</title>
 </head>
 <body>
-<p>안녕하세요, 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+<div style="text-align: center; font-size: 13px; line-height: 2">
+    <img
+            src="https://kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com/email/kumoh-talk-header.png"
+            alt="배너 이미지"
+            width="480"
+            height="140"
+            style="border-radius: 15px"
+    />
 
-<p>지난 야밤의금오톡 IT 세미나에서 진행되었던 내용에 대한 게시물이 업로드 되었습니다.</p>
+    <h2 style="text-align: center; margin: 2px">📚 세미나 공지사항</h2>
+    <p>안녕하세요. 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
+    <p>제 <span>[#회차 입력]</span>회 야밤의금오톡 활동에 대한 공고입니다.</p>
+    <p>금주 세미나 활동 주제는 다음과 같습니다.</p>
 
-<p>본 게시글에는 세미나에서 다뤘던 핵심 내용이 간결하게 정리되어 있으니,<br>
-    발표에서 다룬 주요 사항들을 확인하시고 여러분의 학습에 도움이 되기를 바랍니다.</p>
+    <ul style="list-style-type: none; padding: 5px">
+        <li>
+            <h3 style="margin: 2px">
+            <span
+                    style="
+                color: #2b4577;
+                background-color: #eaeaea;
+                padding: 0px 7px;
+                border-radius: 4px;
+                display: inline-block;
+              "
+            >[#태그 입력]</span
+            >
+                <span>[#제목 입력]</span>
+            </h3>
+            <div style="height: 4px"></div>
+            <ul style="list-style-type: none">
+                <li>
+                    <h4 style="margin: 2px">
+                        발표자 : <span>[#학과 입력]</span>과
+                        <span>[#학번 입력]</span>학번
+                        <span>[#이름 입력]</span>
+                    </h4>
+                </li>
+                <li>
+                    <h4 style="margin: 2px">
+                        시간 : [<span>[#시 입력]</span> : <span>[#분 입력]</span> ~
+                        <span>[#시 입력]</span> : <span>[#분 입력]</span>]
+                    </h4>
+                </li>
+            </ul>
+        </li>
+        <div style="height: 20px"></div>
+        <li>
+            <h3 style="margin: 2px">
+            <span
+                    style="
+                color: #2b4577;
+                background-color: #eaeaea;
+                padding: 0px 7px;
+                border-radius: 4px;
+                display: inline-block;
+              "
+            >[#태그 입력]</span
+            >
+                <span>[#제목 입력]</span>
+            </h3>
+            <div style="height: 4px"></div>
+            <ul style="list-style-type: none">
+                <li>
+                    <h4 style="margin: 2px">
+                        발표자 : <span>[#학과 입력]</span>과
+                        <span>[#학번 입력]</span>학번
+                        <span>[#이름 입력]</span>
+                    </h4>
+                </li>
+                <li>
+                    <h4 style="margin: 2px">
+                        시간 : [<span>[#시 입력]</span> : <span>[#분 입력]</span> ~
+                        <span>[#시 입력]</span> : <span>[#분 입력]</span>]
+                    </h4>
+                </li>
+            </ul>
+        </li>
+    </ul>
 
-<ul>
-    <li>
-        <h3>주제 : <span th:text="${title}">게시글 제목</span></h3>
-    </li>
-    <li>
-        <h3>작성자 : <span th:text="${author}">작성자</span></h3>
-    </li>
-    <li>
-        <h3>게시글 바로가기 : <a th:href="${link}"> 게시글 링크</a></h3>
-    </li>
-</ul>
+    <p>
+        세미나에 참여하여 함께 학습하고자 하는 여러분들의 많은 관심
+        부탁드립니다.
+    </p>
 
-<p>
-    세미나의 녹화본을 보고 싶으신 분들은 아래에서 확인하실 수 있습니다.<br>
-    <strong>유튜브 바로가기: </strong>
-    <a href="https://www.youtube.com/@midnight_kumoh_talk">https://www.youtube.com/@midnight_kumoh_talk</a>
-</p>
+    <hr style="width: 480px; margin: 25px auto" />
 
-<p>
-    게시글을 읽으신 후 궁금한 점이나 더 알고 싶은 내용이 있으시면, 댓글로
-    남겨주시면 감사하겠습니다.
-</p>
-
-<p>[야밤의 금오톡 기술 블로그팀]</p>
+    <img
+            src="https://kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com/email/kumoh-talk-logo.jpeg"
+            alt="로고 이미지"
+            width="40"
+    /><br />
+    <a th:href="${youtubeUrl}" style="line-height: 3.5">야밤의금오톡 Youtube</a>
+    <br />
+    <a
+            th:href="${changeSubscribeUrl}"
+            style="color: gray; font-size: 10px; text-decoration: none"
+    >구독정보 변경하기</a
+    >
+    <span style="color: gray; padding: 0.3%">|</span>
+    <a
+            th:href="${cancelSubscribeUrl}"
+            style="color: gray; font-size: 10px; text-decoration: none"
+    >구독취소</a
+    >
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/seminar_summary.html
+++ b/src/main/resources/templates/seminar_summary.html
@@ -3,10 +3,10 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>[야밤의금오톡] '스터디 팀원 공고' 새 글 알림</title>
+    <title>[야밤의금오톡] '세미나 발표 정리' 새 글 알림</title>
 </head>
 <body>
-<div style="text-align: center; font-size: 13px; line-height: 2">
+<div style="text-align: center; font-size: 13px; line-height: 2.3">
     <img
             src="https://kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com/email/kumoh-talk-header.png"
             alt="배너 이미지"
@@ -15,45 +15,16 @@
             style="border-radius: 15px"
     />
 
-    <h2 style="text-align: center; margin: 2px">📚 스터디 새 글 발행</h2>
+    <h2 style="text-align: center; margin: 2px">📚 세미나 새 글 발행</h2>
     <p>안녕하세요. 야밤의금오톡 뉴스레터를 구독해주신 여러분!</p>
-    <div style="height: 2px"></div>
-    <p>
-        새로운
-        <span
-                th:text="${type}"
-                style="
-            color: #2b4577;
-            background-color: #eaeaea;
-            padding: 0px 4px;
-            border-radius: 4px;
-            display: inline-block;
-          "
-        >스터디</span
-        >
-        그룹을 모집하는 게시글이 게시되었습니다.
-    </p>
-    <div style="height: 4px"></div>
-    <p>
-        <span
-                th:text="${tag}"
-                style="
-            color: #2b4577;
-            background-color: #eaeaea;
-            padding: 0px 4px;
-            border-radius: 4px;
-            display: inline-block;
-          "
-        >개발직군</span
-        >에 관심이 있는 분들은,
-    </p>
-    <div style="height: 4px"></div>
-    <p>아래 게시글을 통해 자세한 내용을 확인해주시기 바랍니다.</p>
+    <p>지난 야밤의금오톡 IT 세미나 내용에 대한 게시물이 업로드 되었습니다.</p>
+    <p>게시글을 읽으신 후 궁금한 점이나 더 알고 싶은 내용이 있으시면,</p>
+    <p>게시글 댓글로 남겨주시면 감사하겠습니다.</p>
 
     <ul style="list-style-type: none; padding: 0">
         <li>
             <h4 style="margin: 2px">
-                스터디 주제 : <span th:text="${title}">주제</span>
+                제목 : <span th:text="${title}">제목</span>
             </h4>
         </li>
         <li>
@@ -67,14 +38,6 @@
             </h4>
         </li>
     </ul>
-    <p>
-        스터디에 참여하여 함께 학습하고자 하는 여러분들의 많은 관심
-        부탁드립니다.
-    </p>
-    <p>
-        추가 문의사항이 있으신 분들은 게시글 아래 댓글로 문의해주시면
-        감사하겠습니다.
-    </p>
     <hr style="width: 480px; margin: 15px auto" />
 
     <img


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 자잘한 오류를 수정했습니다. (fix)
- 뉴스레터 폼이 완성됨에 따라 관련 기능들을 마무리 했습니다. 이 부분은 기존 이메일 전송 부분에 변경점이 없어도 됩니다.
- filter 단에서 ADMIN 권한이 들어왔을 때, DB를 들러 확인하는 로직을 추가했습니다.
- 뉴스레터 기능을 비회원도 이용할 수 있게끔 설정했습니다. (사용자 계정과의 연동은 다음 버전으로..)
- 질문이 필요없는 ADMIN api를 작성했습니다.
  - commit이 너무 쌓여서 swagger 연동과 질문이 필요한 ADMIN api 는 추후 PR로 올리겠습니다.

### ❓ 리뷰 포인트
- `GlobalPageResponse` 에서 제너릭을 통해 모든 필드를 받을 수 있는 메서드를 추가했습니다.
- 잘못된 부분이 있다면 리뷰 남겨주세요~

### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
