### PR TITLE
모집 게시물 API 및 dev 서버 CI/CD 파이프라인 리팩토링

### DIFF
--- a/.github/workflows/develop-cicd-gradle.yml
+++ b/.github/workflows/develop-cicd-gradle.yml
@@ -71,27 +71,18 @@ jobs:
         id: build-image
         run: |
           docker build -t kumoh_talk:latest .
-          docker save kumoh_talk:latest -o kumoh_talk:latest.tar
+          docker save kumoh_talk:latest -o ./dev_exe/kumoh_talk:latest.tar
 
-      - name: Upload to S3
+      - name: Compress dev_exe folder
         run: |
-          aws s3 cp kumoh_talk:latest.tar s3://${{ secrets.S3_BUCKET_NAME }}/kumoh_talk:latest.tar
+          zip -r dev_exe.zip dev_exe
 
-      - name: Create .env file
+      - name: Send zip file to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
         run: |
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> .env
-          echo "USE_PROFILE=dev" >> .env
-
-      - name: SSH Connect
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.DEV_HOST }}
-          username: ubuntu
-          key: ${{ secrets.DEV_EC2_PRIVATE_KEY }}
-          script: |
-            sudo docker stop spring-boot-app || true
-            sudo docker rm spring-boot-app || true
-            aws s3 cp s3://${{ secrets.S3_BUCKET_NAME }}/kumoh_talk:latest.tar kumoh_talk:latest.tar
-            sudo docker load -i kumoh_talk:latest.tar
-            docker-compose up -d
-            sudo docker image prune -a -f
+          FILE_PATH="dev_exe.zip"  # 압축된 파일의 경로
+          curl -X POST -H "Content-Type: multipart/form-data" \
+          -F "file=@${FILE_PATH}" \
+          -F "payload_json={\"content\": \"Here is the dev_exe folder as a zip file:\"}" \
+          "${DISCORD_WEBHOOK_URL}"

--- a/.github/workflows/develop-cicd-gradle.yml
+++ b/.github/workflows/develop-cicd-gradle.yml
@@ -82,7 +82,8 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
         run: |
           FILE_PATH="dev_exe.zip"  # 압축된 파일의 경로
+          PR_TITLE="${{ github.event.pull_request.title }}"  # PR 제목 가져오기
           curl -X POST -H "Content-Type: multipart/form-data" \
           -F "file=@${FILE_PATH}" \
-          -F "payload_json={\"content\": \"Here is the dev_exe folder as a zip file:\"}" \
+          -F "payload_json={\"content\": \"Here is the ${PR_TITLE} folder as a zip file:\"}" \
           "${DISCORD_WEBHOOK_URL}"

--- a/dev_exe/docker-compose.yml
+++ b/dev_exe/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+
+services:
+  spring-boot-app:
+    image: kumoh_talk:latest
+    container_name: spring-boot-app
+    ports:
+      - "8080:8080"  # 백엔드 API 포트
+    environment:
+      - USE_PROFILE=dev
+    depends_on:
+      kumoh-talk-mysql:
+        condition: service_healthy
+      kumoh-talk-redis:
+        condition: service_healthy
+
+  kumoh-talk-mysql:
+    image: mysql:latest
+    container_name: kumoh-talk-mysql
+    ports:
+      - 3310:3306
+    environment:
+      MYSQL_DATABASE: kumoh_talk
+      MYSQL_CHARSET: utf8mb4
+      MYSQL_ROOT_PASSWORD: kumohtalk1234@
+      MYSQL_COLLATION: utf8mb4_unicode_ci
+    restart: always  # 자동 재시작 설정
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kumoh-talk-redis:
+    image: redis
+    command: redis-server --port 6379
+    container_name: kumoh-talk-redis
+    ports:
+      - "6381:6379"
+    restart: always  # 자동 재시작 설정
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/dev_exe/macOs.sh
+++ b/dev_exe/macOs.sh
@@ -1,0 +1,5 @@
+sudo docker stop spring-boot-app || true
+sudo docker rm spring-boot-app || true
+sudo docker load -i kumoh_talk:latest.tar
+docker-compose up -d
+sudo docker image prune -a -f

--- a/dev_exe/windowsOs.bat
+++ b/dev_exe/windowsOs.bat
@@ -1,0 +1,6 @@
+@echo off
+docker stop spring-boot-app || exit 0
+docker rm spring-boot-app || exit 0
+docker load -i kumoh_talk:latest.tar
+docker-compose up -d
+docker image prune -a -f

--- a/src/main/java/com/example/demo/domain/comment/controller/swagger/CommentApi.java
+++ b/src/main/java/com/example/demo/domain/comment/controller/swagger/CommentApi.java
@@ -44,7 +44,8 @@ public interface CommentApi {
     )
     ResponseEntity<ResponseBody<CommentResponse>> getBoardComments(
             @PathVariable Long boardId,
-            @Parameter(description = "게시물 타입(basic, recruitment)", example = "basic") @RequestParam CommentTargetBoardType commentTargetBoardType);
+            @Parameter(description = "게시물 타입(basic, recruitment) \n" +
+                    "세미나, 공지사항 게시물은 basic, 스멘프 게시물은 recruitment로 설정", example = "basic") @RequestParam CommentTargetBoardType commentTargetBoardType);
 
     @Operation(
             summary = "사용자 작성 댓글 페이지 조회",
@@ -83,7 +84,8 @@ public interface CommentApi {
     ResponseEntity<ResponseBody<CommentInfoResponse>> createComment(
             @Parameter(hidden = true) Long userId,
             @PathVariable Long boardId,
-            @Parameter(description = "게시물 타입(basic, recruitment)", example = "basic") @RequestParam CommentTargetBoardType commentTargetBoardType,
+            @Parameter(description = "게시물 타입(basic, recruitment) \n" +
+                    "세미나, 공지사항 게시물은 basic, 스멘프 게시물은 recruitment로 설정", example = "basic") @RequestParam CommentTargetBoardType commentTargetBoardType,
             @RequestBody @Valid CommentRequest commentRequest);
 
     @Operation(

--- a/src/main/java/com/example/demo/domain/recruitment_application/controller/swagger/RecruitmentApplicationApi.java
+++ b/src/main/java/com/example/demo/domain/recruitment_application/controller/swagger/RecruitmentApplicationApi.java
@@ -29,7 +29,8 @@ public interface RecruitmentApplicationApi {
 
     @Operation(
             summary = "모집 신청 저장",
-            description = "recruitmentBoardId에 해당하는 모집 게시물에 신청을 저장합니다."
+            description = "recruitmentBoardId에 해당하는 모집 게시물에 신청을 저장합니다. \n" +
+                    "마감 기한 이전에 신청이 가능합니다."
     )
     @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecruitmentApplicationResponse.class)))
     @ApiResponseExplanations(
@@ -92,7 +93,8 @@ public interface RecruitmentApplicationApi {
 
     @Operation(
             summary = "신청서 수정",
-            description = "applicantId에 해당하는 신청서를 수정합니다."
+            description = "applicantId에 해당하는 신청서를 수정합니다.\n" +
+                    "마감기한 이전에 수정이 가능합니다."
     )
     @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecruitmentApplicationResponse.class)))
     @ApiResponseExplanations(
@@ -118,7 +120,8 @@ public interface RecruitmentApplicationApi {
 
     @Operation(
             summary = "신청서 삭제",
-            description = "applicantId에 해당하는 신청서를 삭제합니다."
+            description = "applicantId에 해당하는 신청서를 삭제합니다.\n" +
+                    "마감 기한 이전에 삭제가 가능합니다."
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(

--- a/src/main/java/com/example/demo/domain/recruitment_board/controller/RecruitmentBoardController.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/controller/RecruitmentBoardController.java
@@ -97,19 +97,21 @@ public class RecruitmentBoardController implements RecruitmentBoardApi {
      * [모집 게시물 정보 상세조회] <br>
      * 모집 게시물 리스트에서 게시물 클릭 시 상세조회 하는 기능
      */
+    @AssignUserId(required = false)
     @GetMapping("/{recruitmentBoardId}/board")
-    public ResponseEntity<ResponseBody<RecruitmentBoardInfoResponse>> getRecruitmentBoardInfo(@PathVariable Long recruitmentBoardId) {
-        return ResponseEntity.ok(createSuccessResponse(recruitmentBoardService.getBoardInfo(recruitmentBoardId)));
+    public ResponseEntity<ResponseBody<RecruitmentBoardInfoResponse>> getRecruitmentBoardInfo(Long userId, @PathVariable Long recruitmentBoardId) {
+        return ResponseEntity.ok(createSuccessResponse(recruitmentBoardService.getBoardInfo(userId, recruitmentBoardId)));
     }
 
     /**
      * [모집 게시물 신청폼 상세조회] <br>
      * 모집 게시물 신청 페이지에서 보여질 신청 질문 리스트 조회 기능
      */
+    @AssignUserId(required = false)
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_ACTIVE_USER')")
     @GetMapping("/{recruitmentBoardId}/form")
-    public ResponseEntity<ResponseBody<List<RecruitmentFormQuestionResponse>>> getRecruitmentFormInfo(@PathVariable Long recruitmentBoardId) {
-        return ResponseEntity.ok(createSuccessResponse(recruitmentBoardService.getFormInfoList(recruitmentBoardId)));
+    public ResponseEntity<ResponseBody<List<RecruitmentFormQuestionResponse>>> getRecruitmentFormInfo(Long userId, @PathVariable Long recruitmentBoardId) {
+        return ResponseEntity.ok(createSuccessResponse(recruitmentBoardService.getFormInfoList(userId, recruitmentBoardId)));
     }
 
     /**

--- a/src/main/java/com/example/demo/domain/recruitment_board/controller/RecruitmentBoardController.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/controller/RecruitmentBoardController.java
@@ -65,6 +65,7 @@ public class RecruitmentBoardController implements RecruitmentBoardApi {
      * @apiNote 1. 이전 페이지에서 출력한 가장 마지막 게시물의 Id를 lastBoardId에 실어 요청하면, 다음 게시물부터 페이징 사이즈에 맞게 응답 <br>
      * 2. 가장 처음 요청을 위해 lastBoardId은 nullable로 설정 <br>
      * -> lastBoardId가 널이라면 서비스 로직에서 맨 처음 게시물 Id를 조회하여 그 게시물부터 페이징 사이즈에 맞게 응답 <br>
+     * 3. 정렬 기준 : 모집 마감일 오름차순
      */
     @GetMapping("/no-offset")
     public ResponseEntity<ResponseBody<RecruitmentBoardNoOffsetResponse>> getRecruitmentBoardListByNoOffset(
@@ -180,7 +181,8 @@ public class RecruitmentBoardController implements RecruitmentBoardApi {
      *
      * @param size        한 페이지의 사이즈
      * @param lastBoardId 이전 페이지 마지막 게시물 Id(nullable)
-     * @apiNote 현재 도메인의 /no-offset API 설명 참조
+     * @apiNote 1. 현재 도메인의 /no-offset API 설명 참조
+     * 2. 정렬 기준 : 생성 날짜 내림차순
      */
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_ACTIVE_USER')")

--- a/src/main/java/com/example/demo/domain/recruitment_board/controller/RecruitmentBoardController.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/controller/RecruitmentBoardController.java
@@ -96,6 +96,8 @@ public class RecruitmentBoardController implements RecruitmentBoardApi {
     /**
      * [모집 게시물 정보 상세조회] <br>
      * 모집 게시물 리스트에서 게시물 클릭 시 상세조회 하는 기능
+     *
+     * @apiNote 1. 임시저장 게시물은 작성자만 조회할 수 있도록 구현
      */
     @AssignUserId(required = false)
     @GetMapping("/{recruitmentBoardId}/board")
@@ -106,6 +108,9 @@ public class RecruitmentBoardController implements RecruitmentBoardApi {
     /**
      * [모집 게시물 신청폼 상세조회] <br>
      * 모집 게시물 신청 페이지에서 보여질 신청 질문 리스트 조회 기능
+     *
+     * @apiNote 1. 임서저장 신청폼은 작성자만 조회할 수 있도록 구현 <br>
+     * 2. 마감기한이 지난 경우 작성자가 아니면 폼 조회를 할 수 없도록 구현
      */
     @AssignUserId(required = false)
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_ACTIVE_USER')")

--- a/src/main/java/com/example/demo/domain/recruitment_board/controller/RecruitmentBoardController.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/controller/RecruitmentBoardController.java
@@ -104,7 +104,7 @@ public class RecruitmentBoardController implements RecruitmentBoardApi {
 
     /**
      * [모집 게시물 신청폼 상세조회] <br>
-     * 모집 게시물 신청 페이지에서 보여질 신청 질문 리스트 조지 기능
+     * 모집 게시물 신청 페이지에서 보여질 신청 질문 리스트 조회 기능
      */
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_ACTIVE_USER')")
     @GetMapping("/{recruitmentBoardId}/form")
@@ -186,8 +186,8 @@ public class RecruitmentBoardController implements RecruitmentBoardApi {
     }
 
     /**
-     * [사용자의 임시저장 게시물 페이징 리스트 조회] <br>
-     * 페이지 번호로 구현한 사용자 임시서장 게시물 페이징 리스트 조회 기능
+     * [사용자 작성 게시물 페이징 리스트 조회] <br>
+     * 페이지 번호로 구현한 사용자 작성 게시물 페이징 리스트 조회 기능
      *
      * @param pageable             페이지 번호(page), 페이지 사이즈(size), 페이지 정렬 조건 및 정렬 방향(sort) <br>
      *                             -> 정렬 조건은 createdAt <br>

--- a/src/main/java/com/example/demo/domain/recruitment_board/controller/swagger/RecruitmentBoardApi.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/controller/swagger/RecruitmentBoardApi.java
@@ -81,7 +81,8 @@ public interface RecruitmentBoardApi {
 
     @Operation(
             summary = "모집 게시물 정보 상세조회",
-            description = "recruitmentBoardId에 해당하는 모집 게시물 정보를 상세조회 합니다."
+            description = "recruitmentBoardId에 해당하는 모집 게시물 정보를 상세조회 합니다.\n" +
+                    "임시저장 게시물은 작성자만이 조회할 수 있습니다."
     )
     @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecruitmentBoardInfoResponse.class)))
     @ApiResponseExplanations(
@@ -99,7 +100,9 @@ public interface RecruitmentBoardApi {
 
     @Operation(
             summary = "모집 게시물 신청폼 상세조회",
-            description = "recruitmentBoardId에 해당하는 모집 게시물 신청폼을 상세조회 합니다."
+            description = "recruitmentBoardId에 해당하는 모집 게시물 신청폼을 상세조회 합니다. \n" +
+                    "임시저장 신청폼은 작성자만이 조회할 수 있습니다. \n" +
+                    "마감기한이 지난 신청폼은 작성자만이 조회 할 수 있습니다."
     )
     @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecruitmentFormQuestionResponse.class)))
     @ApiResponseExplanations(
@@ -117,8 +120,9 @@ public interface RecruitmentBoardApi {
 
     @Operation(
             summary = "모집 게시물 정보 및 신청폼 수정",
-            description = "recruitmentBoardId에 해당하는 모집 게시물 정보 및 신청폼을 수정합니다.\n" +
-                    "만약 임시저장된 게시물을 불러온 후 그 게시물을 저장한다면 저장 api가 아닌 수정 api를 요청해야합니다."
+            description = "recruitmentBoardId에 해당하는 모집 게시물 정보 및 신청폼을 수정합니다. \n" +
+                    "만약 임시저장된 게시물을 불러온 후 그 게시물을 저장한다면 저장 api가 아닌 수정 api를 요청해야합니다. \n" +
+                    "게시물의 신청자가 한 명이라도 있으면 게시물 수정이 불가능합니다."
     )
     @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecruitmentBoardInfoAndFormResponse.class)))
     @ApiResponseExplanations(
@@ -156,7 +160,8 @@ public interface RecruitmentBoardApi {
 
     @Operation(
             summary = "사용자의 최근 임시저장 모집 게시물 조회",
-            description = "사용자가 최근에 임시저장한 모집 게시물을 조회합니다."
+            description = "사용자가 최근에 임시저장한 모집 게시물을 조회합니다.\n" +
+                    "최근 임시저장 게시물이 없다면, board, form에 null이 응답됩니다."
     )
     @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecruitmentBoardInfoAndFormResponse.class)))
     @ApiResponseExplanations(
@@ -164,8 +169,7 @@ public interface RecruitmentBoardApi {
                     responseClass = RecruitmentBoardInfoAndFormResponse.class,
                     description = "사용자 최근 임시저장 모집 게시물 조회 성공"),
             errors = {
-                    @ApiErrorResponseExplanation(errorCode = ErrorCode.USER_NOT_FOUND),
-                    @ApiErrorResponseExplanation(errorCode = ErrorCode.BOARD_NOT_FOUND)
+                    @ApiErrorResponseExplanation(errorCode = ErrorCode.USER_NOT_FOUND)
             }
     )
     ResponseEntity<ResponseBody<RecruitmentBoardInfoAndFormResponse>> getDraftRecruitmentBoard(

--- a/src/main/java/com/example/demo/domain/recruitment_board/controller/swagger/RecruitmentBoardApi.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/controller/swagger/RecruitmentBoardApi.java
@@ -186,14 +186,14 @@ public interface RecruitmentBoardApi {
 
 
     @Operation(
-            summary = "페이지 번호 방식 사용자 임시저장 모집 게시물 페이지 조회",
-            description = "페이지 번호를 통해 사용자의 임시저장 모집 게시물 목록 페이지를 조회합니다."
+            summary = "페이지 번호 방식 사용자 작성 모집 게시물 페이지 조회",
+            description = "페이지 번호를 통해 사용자가 작성한 모집 게시물 목록 페이지를 조회합니다."
     )
     @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecruitmentBoardPageNumResponse.class)))
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(
                     responseClass = RecruitmentBoardPageNumResponse.class,
-                    description = "사용자 임시저장 모집 게시물 페이지 조회 성공"),
+                    description = "사용자 작성 시모집 게시물 페이지 조회 성공"),
             errors = {
                     @ApiErrorResponseExplanation(errorCode = ErrorCode.USER_NOT_FOUND)
             }

--- a/src/main/java/com/example/demo/domain/recruitment_board/controller/swagger/RecruitmentBoardApi.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/controller/swagger/RecruitmentBoardApi.java
@@ -89,10 +89,13 @@ public interface RecruitmentBoardApi {
                     responseClass = RecruitmentBoardInfoResponse.class,
                     description = "모집 게시물 정보 상세조회 성공"),
             errors = {
-                    @ApiErrorResponseExplanation(errorCode = ErrorCode.BOARD_NOT_FOUND)
+                    @ApiErrorResponseExplanation(errorCode = ErrorCode.BOARD_NOT_FOUND),
+                    @ApiErrorResponseExplanation(errorCode = ErrorCode.DRAFT_NOT_ACCESS_USER)
+
             }
     )
-    ResponseEntity<ResponseBody<RecruitmentBoardInfoResponse>> getRecruitmentBoardInfo(@PathVariable Long recruitmentBoardId);
+    ResponseEntity<ResponseBody<RecruitmentBoardInfoResponse>> getRecruitmentBoardInfo(
+            @Parameter(hidden = true) Long userId, @PathVariable Long recruitmentBoardId);
 
     @Operation(
             summary = "모집 게시물 신청폼 상세조회",
@@ -105,10 +108,12 @@ public interface RecruitmentBoardApi {
                     description = "모집 게시물 신청폼 상세조회 성공"),
             errors = {
                     @ApiErrorResponseExplanation(errorCode = ErrorCode.BOARD_NOT_FOUND),
-                    @ApiErrorResponseExplanation(errorCode = ErrorCode.ACCESS_DENIED)
+                    @ApiErrorResponseExplanation(errorCode = ErrorCode.ACCESS_DENIED),
+                    @ApiErrorResponseExplanation(errorCode = ErrorCode.DRAFT_NOT_ACCESS_USER)
             }
     )
-    ResponseEntity<ResponseBody<List<RecruitmentFormQuestionResponse>>> getRecruitmentFormInfo(@PathVariable Long recruitmentBoardId);
+    ResponseEntity<ResponseBody<List<RecruitmentFormQuestionResponse>>> getRecruitmentFormInfo(
+            @Parameter(hidden = true) Long userId, @PathVariable Long recruitmentBoardId);
 
     @Operation(
             summary = "모집 게시물 정보 및 신청폼 수정",

--- a/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/request/RecruitmentBoardInfoRequest.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/request/RecruitmentBoardInfoRequest.java
@@ -35,11 +35,11 @@ public class RecruitmentBoardInfoRequest {
     @Size(min = 1, max = 1000, message = "본문 내용 최대 길이는 1000글자 입니다.")
     private String content;
 
-    @Schema(description = "모집 게시물 타입 정보(study, project, mentoring, seminar_notice, seminar_summary)", example = "study")
+    @Schema(description = "모집 게시물 타입 정보[study, project, mentoring]", example = "study")
     @NotNull(message = "타입을 선택해야합니다.")
     private RecruitmentBoardType type;
 
-    @Schema(description = "모집 게시물 태그 정보(frontend, backend, ai, mobile, security)", example = "frontend")
+    @Schema(description = "모집 게시물 태그 정보[frontend, backend, ai, mobile, security, etc]", example = "frontend")
     @NotNull(message = "태그를 선택해야합니다.")
     private RecruitmentBoardTag tag;
 

--- a/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/request/RecruitmentFormQuestionRequest.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/request/RecruitmentFormQuestionRequest.java
@@ -27,7 +27,7 @@ public class RecruitmentFormQuestionRequest {
     @Size(min = 1, max = 100, message = "질문 최대 길이는 100글자 입니다.")
     private String question;
 
-    @Schema(description = "신청폼 질문 타입 정보(choice, description, checkbox)", example = "description")
+    @Schema(description = "신청폼 질문 타입 정보[choice, description, checkbox]", example = "description")
     @NotNull(message = "질문 타입을 선택해야합니다.")
     private QuestionType type;
 

--- a/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentBoardInfoResponse.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentBoardInfoResponse.java
@@ -31,9 +31,9 @@ public class RecruitmentBoardInfoResponse {
     private String host;
     @Schema(description = "모집 게시물 내용 정보", example = "board content")
     private String content;
-    @Schema(description = "모집 게시물 타입 정보", example = "STUDY")
+    @Schema(description = "모집 게시물 타입 정보[STUDY, PROJECT, MENTORING]", example = "STUDY")
     private RecruitmentBoardType type;
-    @Schema(description = "모집 게시물 태그 정보", example = "FRONTEND")
+    @Schema(description = "모집 게시물 태그 정보[FRONTEND, BACKEND, AI, MOBILE, SECURITY, ETC]", example = "FRONTEND")
     private RecruitmentBoardTag tag;
     @Schema(description = "모집 게시물 상태 정보", example = "PUBLISHED")
     private Status status;

--- a/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentBoardNoOffsetResponse.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentBoardNoOffsetResponse.java
@@ -60,9 +60,9 @@ public class RecruitmentBoardNoOffsetResponse {
         private String title;
         @Schema(description = "모집 게시물 요약 내용 정보", example = "board summary")
         private String summary;
-        @Schema(description = "모집 게시물 타입 정보", example = "STUDY")
+        @Schema(description = "모집 게시물 타입 정보[STUDY, PROJECT, MENTORING]", example = "STUDY")
         private RecruitmentBoardType type;
-        @Schema(description = "모집 게시물 태그 정보", example = "FRONTEND")
+        @Schema(description = "모집 게시물 태그 정보[FRONTEND, BACKEND, AI, MOBILE, SECURITY, ETC]", example = "FRONTEND")
         private RecruitmentBoardTag tag;
         @Schema(description = "모집 게시물 모집 대상 정보", example = "people using spring")
         private String recruitmentTarget;

--- a/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentFormQuestionResponse.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentFormQuestionResponse.java
@@ -24,7 +24,7 @@ public class RecruitmentFormQuestionResponse {
     private Integer number;
     @Schema(description = "신청폼 질문 내용 정보", example = "what is your hobby?")
     private String question;
-    @Schema(description = "신청폼 질문 타입 정보", example = "DESCRIPTION")
+    @Schema(description = "신청폼 질문 타입 정보[CHOICE, DESCRIPTION, CHECKBOX]", example = "DESCRIPTION")
     private QuestionType type;
     @Schema(description = "신청폼 질문 필수여부 정보", example = "true")
     private Boolean isEssential;

--- a/src/main/java/com/example/demo/domain/recruitment_board/domain/vo/RecruitmentBoardTag.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/domain/vo/RecruitmentBoardTag.java
@@ -9,7 +9,8 @@ public enum RecruitmentBoardTag {
     BACKEND,
     AI,
     MOBILE,
-    SECURITY;
+    SECURITY,
+    ETC;
 
     public static final String errorMsg = "태그는 frontend, backend, ai, mobile, security 중 하나여야 합니다.";
 

--- a/src/main/java/com/example/demo/domain/recruitment_board/repository/QueryDslRecruitmentBoardRepositoryImpl.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/repository/QueryDslRecruitmentBoardRepositoryImpl.java
@@ -42,20 +42,24 @@ public class QueryDslRecruitmentBoardRepositoryImpl implements QueryDslRecruitme
                             recruitmentBoard.type.eq(boardType),
                             recruitmentBoard.status.eq(Status.PUBLISHED))
 //                .where(recruitment.user.id.ne(userId))
-                    .orderBy(recruitmentBoard.recruitmentDeadline.asc())
+                    .orderBy(recruitmentBoard.recruitmentDeadline.asc(), recruitmentBoard.id.asc())
                     .limit(size + 1)
                     .fetch();
         } else {
             return jpaQueryFactory
                     .selectFrom(recruitmentBoard)
                     .join(recruitmentBoard.user, user).fetchJoin()
-                    .where(recruitmentBoard.recruitmentDeadline.goe(LocalDateTime.now()),
-                            recruitmentBoard.recruitmentDeadline.goe(lastBoard.getRecruitmentDeadline()),
-                            recruitmentBoard.id.ne(lastBoard.getId()),
-                            recruitmentBoard.type.eq(boardType),
-                            recruitmentBoard.status.eq(Status.PUBLISHED))
+                    .where(recruitmentBoard.recruitmentDeadline.goe(LocalDateTime.now())
+                            .and(recruitmentBoard.type.eq(boardType))
+                            .and(recruitmentBoard.status.eq(Status.PUBLISHED))
+                            .and(
+                                    recruitmentBoard.recruitmentDeadline.eq(lastBoard.getRecruitmentDeadline())
+                                            .and(recruitmentBoard.id.gt(lastBoard.getId()))
+                                            .or(recruitmentBoard.recruitmentDeadline.gt(lastBoard.getRecruitmentDeadline()))
+                            )
+                    )
 //                .where(recruitment.user.id.ne(userId))
-                    .orderBy(recruitmentBoard.recruitmentDeadline.asc())
+                    .orderBy(recruitmentBoard.recruitmentDeadline.asc(), recruitmentBoard.id.asc())
                     .limit(size + 1)
                     .fetch();
         }

--- a/src/main/java/com/example/demo/domain/recruitment_board/repository/RecruitmentBoardRepository.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/repository/RecruitmentBoardRepository.java
@@ -13,7 +13,7 @@ public interface RecruitmentBoardRepository extends JpaRepository<RecruitmentBoa
             "where sb.recruitmentDeadline >= CURRENT_TIMESTAMP " +
             "and sb.status = com.example.demo.domain.board.domain.dto.vo.Status.PUBLISHED " +
             "and sb.type = :boardType " +
-            "order by sb.recruitmentDeadline asc")
+            "order by sb.recruitmentDeadline asc, sb.id asc")
     List<Long> findPublishedId(RecruitmentBoardType boardType);
 
     @Query("Select Max(id) From RecruitmentBoard " +

--- a/src/main/java/com/example/demo/global/aop/AssignUserId.java
+++ b/src/main/java/com/example/demo/global/aop/AssignUserId.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface AssignUserId {
+    boolean required() default true;
 }

--- a/src/main/java/com/example/demo/global/aop/UserIdInjectionAspect.java
+++ b/src/main/java/com/example/demo/global/aop/UserIdInjectionAspect.java
@@ -1,51 +1,58 @@
 package com.example.demo.global.aop;
 
+import com.example.demo.global.jwt.JwtAuthentication;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import com.example.demo.global.jwt.JwtAuthentication;
-
-import lombok.extern.slf4j.Slf4j;
-
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
-import java.util.Optional;
 
 @Slf4j
 @Aspect
 @Component
 public class UserIdInjectionAspect {
-	@Pointcut("@annotation(com.example.demo.global.aop.AssignUserId) && (args(userId, ..) || args(.., userId))")
-	public void userIdAnnotatedMethod(Long userId) {}
+    @Pointcut("@annotation(com.example.demo.global.aop.AssignUserId) && (args(userId, ..) || args(.., userId))")
+    public void userIdAnnotatedMethod(Long userId) {
+    }
 
-	@Around(value = "userIdAnnotatedMethod(userId)", argNames = "joinPoint,userId")
-	public Object injectUserId(ProceedingJoinPoint joinPoint, Long userId) throws Throwable {
-		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    @Around(value = "userIdAnnotatedMethod(userId)", argNames = "joinPoint,userId")
+    public Object injectUserId(ProceedingJoinPoint joinPoint, Long userId) throws Throwable {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-		if(authentication instanceof JwtAuthentication) {
-			userId = (Long) authentication.getPrincipal();
-		} else {
-			log.error("JwtAuthentication Type Casting Error {}", authentication.getClass());
-			throw new IllegalArgumentException("Only JWT-based authentication is supported for @AssignUserId annotation.");
-		}
+        if (authentication instanceof JwtAuthentication) {
+            userId = (Long) authentication.getPrincipal();
+        } else if (authentication instanceof AnonymousAuthenticationToken) {
+            MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+            AssignUserId assignUserIdAnnotation = signature.getMethod().getAnnotation(AssignUserId.class);
+            if (assignUserIdAnnotation.required()) {
+                log.error("Null Authentication error {}", authentication.getClass());
+                throw new IllegalArgumentException("You must login to use this service.");
+            } else {
+                userId = null;
+            }
+        } else {
+            log.error("JwtAuthentication Type Casting Error {}", authentication.getClass());
+            throw new IllegalArgumentException("Only JWT-based authentication is supported for @AssignUserId annotation.");
+        }
 
-		Object[] args = joinPoint.getArgs();
-		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-		Parameter[] parameters = signature.getMethod().getParameters();
+        Object[] args = joinPoint.getArgs();
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Parameter[] parameters = signature.getMethod().getParameters();
 
-		for (int i = 0; i < parameters.length; i++) {
-			if (parameters[i].getType() == Long.class && args[i] == null) {
-				args[i] = userId;
-				break;
-			}
-		}
+        for (int i = 0; i < parameters.length; i++) {
+            if (parameters[i].getType() == Long.class && args[i] == null) {
+                args[i] = userId;
+                break;
+            }
+        }
 
-		return joinPoint.proceed(args);
-	}
+        return joinPoint.proceed(args);
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,7 +31,7 @@ spring:
     show-sql: true
 
 swagger:
-  server-url: http://${dev.backend.ip}:8080
+  server-url: http://localhost:8080
   description: "develop 백엔드 서버"
 
 


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 명세서 및 java doc 오타 수정
- AssignUserId에 required 옵션 추가
- 모집 게시물 리팩토링
  - 임시저장 게시물 및 신청폼 조회 시 유저Id 체크 후 조회하도록 변경
  - 마감기한이 지난 모집 게시물은 신청폼(질문) 조회 불가능하도록 변경
  - 모집 게시물 태그 종류에 기타 추가
  - 모집 게시물 리스트 조회 쿼리 버그 수정
- 로컬에서 dev 서버를 띄울 수 있도록 파일 추가 및 깃허브 액션 변경

### ❓ 리뷰 포인트
1. AssignUserId에 required 옵션 추가
- AssignUserId 어노테이션에 필수 여부를 선택할 수 있는 옵션을 추가하고, 필수 여부가 false이고 로그인 정보가 없는 경우 userId 파라미터에 null을 넣도록 리팩토링 하였습니다.
- 적용한 곳 : 모집 게시물 조회 시 임시저장 게시물을 조회할 경우 로그인 한 유저가 임시저장한 유저인지 확인 후 조회하도록 하기 위해, 필수여부가 false인 AssignUserId 어노테이션을 해당 api에 추가하고 임시저장 모집 게시물 조회이면 userId를 확인하도록 하였습니다.

2. 모집 게시물 리스트 조회 쿼리 버그 수정
- 수정 전 : 리스트 조회 시 정렬 기준이 마감일 오름차순이고, 주어진 lastBoardId에 해당하는 게시물보다 마감일이 느린 게시물을 조회하도록 하였습니다.
- 수정 후 : 주어진 lastBoardId에 해당하는 게시물과 마감일이 동일한 게시물이 존재할 수도 있으므로, 정렬 기준에 마감일이 동일하면 id 오름차순으로 정렬하도록 정렬기준을 추가하고 이를 where 절에 조건으로 추가했습니다.

3. 로컬에서 dev 서버를 띄울 수 있도록 파일 추가 및 깃허브 액션 변경
- 루트 경로에 dev_exe 폴더를 만들어서 docker-compose.yml, Mac 전용 쉘 스크립트, Windows 전용 배치 스크립트, API 서버 도커 이미지 파일이 포함되도록 하였습니다.
- 깃허브 액션에서 빌드를 성공적으로 완료하면 디스코드 웹훅을 통해 해당 폴더를 zip으로 압축하여 전송되도록 깃허브 액션을 수정하였습니다.
- 머지 후 정상적으로 잘 굴러가는지 확인이 필요할 것 같습니다..
### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
