### PR TITLE
UserController 닉네임 중복체크 api 수정 및 테스트 코드 작성

### DIFF
--- a/.github/workflows/develop-cicd-gradle.yml
+++ b/.github/workflows/develop-cicd-gradle.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-libs
           path: build/libs/*.jar
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-libs
           path: build/libs
@@ -95,7 +95,7 @@ jobs:
           docker save kumoh_talk:latest | gzip > kumoh_talk.tar.gz
 
       - name: Upload tar.gz as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kumoh_talk-tar
           path: kumoh_talk.tar.gz

--- a/src/main/java/com/example/demo/domain/user/api/UserApi.java
+++ b/src/main/java/com/example/demo/domain/user/api/UserApi.java
@@ -17,9 +17,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import static com.example.demo.global.regex.UserRegex.NICKNAME_REGEXP;
 
 public interface UserApi {
     @Operation(
@@ -35,7 +38,9 @@ public interface UserApi {
                     @ApiErrorResponseExplanation(errorCode = ErrorCode.EXIST_SAME_NICKNAME),
             }
     )
-    ResponseEntity<ResponseBody<Void>> checkNicknameDuplicate(@Parameter String nickname);
+    ResponseEntity<ResponseBody<Void>> checkNicknameDuplicate(
+            @Parameter(description = "닉네임", required = true)
+            @Pattern(regexp = NICKNAME_REGEXP, message = "닉네임 정규식을 맞춰주세요.") String nickname);
 
     @Operation(
             summary = "GUEST 사용자에 한해서 초기 추가정보를 입력받는 api",

--- a/src/main/java/com/example/demo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/demo/domain/user/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController implements UserApi {
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_GUEST')")
     @GetMapping("/check-nickname")
     public ResponseEntity<ResponseBody<Void>> checkNicknameDuplicate(
-            @Param("nickname") @Pattern(regexp = NICKNAME_REGEXP, message = "닉네임 정규식을 맞춰주세요.") String nickname) {
+            @RequestParam("nickname") @Pattern(regexp = NICKNAME_REGEXP, message = "닉네임 정규식을 맞춰주세요.") String nickname) {
         userService.checkNicknameDuplicate(nickname);
         return ResponseEntity.ok(createSuccessResponse());
     }

--- a/src/test/java/com/example/demo/base/ControllerTest.java
+++ b/src/test/java/com/example/demo/base/ControllerTest.java
@@ -1,13 +1,20 @@
 package com.example.demo.base;
 
+import com.example.demo.domain.newsletter.client.DiscordNewsletterClient;
 import com.example.demo.domain.user.controller.UserController;
 import com.example.demo.domain.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -16,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
                 UserController.class
         },
         excludeAutoConfiguration = {SecurityAutoConfiguration.class}
+
 )
 @AutoConfigureRestDocs
 @WithMockUser
@@ -29,6 +37,5 @@ public abstract class ControllerTest {
 
     @MockBean
     protected UserService userService;
-
 
 }

--- a/src/test/java/com/example/demo/domain/user/api/controller/UserControllerTest.java
+++ b/src/test/java/com/example/demo/domain/user/api/controller/UserControllerTest.java
@@ -1,0 +1,96 @@
+package com.example.demo.domain.user.api.controller;
+
+import com.example.demo.domain.user.controller.UserController;
+import com.example.demo.domain.user.domain.dto.request.CompleteRegistrationRequest;
+import com.example.demo.domain.user.service.UserService;
+import com.example.demo.global.base.exception.ErrorCode;
+import com.example.demo.global.base.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.security.test.context.support.WithMockUser;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test") // application-test.yml이 로드되도록 강제
+@WebMvcTest(controllers = UserController.class,
+        // 보안 자동 구성을 완전히 제외하지 않으면 OAuth2 관련 빈이 로드되어 문제가 생길 수 있음.
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class}
+)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // UserController가 의존하는 UserService를 Mock 처리
+    @MockBean
+    private UserService userService;
+
+    // OAuth2SecurityFilterChain 등이 필요할 경우, SecurityFilterChain을 Mock 처리해서 의존성 문제를 해결
+    @MockBean
+    private SecurityFilterChain securityFilterChain;
+
+    @Test
+    @WithMockUser(username = "test", roles = {"GUEST"})
+    void 성공_게스트_사용자는_닉네임_중복_검사에_통과한다() throws Exception {
+        // given: 유효한 닉네임을 설정하고, userService.checkNicknameDuplicate()가 예외 없이 동작하도록 Mocking
+        String nickname = "nickd";  // 정규식에 맞는 유효한 닉네임
+        Mockito.doNothing().when(userService).checkNicknameDuplicate(nickname);
+
+        // when: /api/v1/users/check-nickname에 GET 요청을 보냄
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/users/check-nickname")
+                        .param("nickname", nickname))
+                        .andDo(print());
+
+        // then: HTTP 200 OK 응답이 반환되는지 검증
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "test", roles = {"GUEST"})
+    void 실패_게스트_사용자는_닉네임_중복_검사에_통과하지_못한다() throws Exception {
+        // given
+        String duplicatedNickname = "nickd";
+        Mockito.doThrow(new ServiceException(ErrorCode.EXIST_SAME_NICKNAME)).when(userService).checkNicknameDuplicate(duplicatedNickname);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/users/check-nickname")
+                        .param("nickname", duplicatedNickname))
+                        .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(username = "test", roles = {"GUEST"})
+    void 성공_게스트_사용자는_회원가입에_필요한_추가정보를_입력한다(){
+        // given
+        Long id = 1L;
+        CompleteRegistrationRequest completeRegistrationRequest =
+                new CompleteRegistrationRequest("iLoveC","tom");
+        Mockito.doNothing().when(userService).completeRegistration(id, completeRegistrationRequest);
+
+        // when
+
+        // then
+
+
+
+    }
+
+}

--- a/src/test/java/com/example/demo/domain/user/api/controller/UserControllerTest.java
+++ b/src/test/java/com/example/demo/domain/user/api/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import com.example.demo.domain.user.service.UserService;
 import com.example.demo.global.base.exception.ErrorCode;
 import com.example.demo.global.base.exception.ServiceException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +77,7 @@ public class UserControllerTest {
         resultActions.andExpect(status().isConflict());
     }
 
+    @Disabled
     @Test
     @WithMockUser(username = "test", roles = {"GUEST"})
     void 성공_게스트_사용자는_회원가입에_필요한_추가정보를_입력한다(){


### PR DESCRIPTION
### 🌱 작업 사항 
- UserController의 닉네임 중복체크 api에 대한 테스트 코드를 작성했습니다
- 테스트 중 발생한 오류 해결을 위해 UserController.java와 UserApi.java의 코드 일부분을 수정했습니다.
- 급하게 올리느라 /complete-registration api의 테스트 코드를 일부분만 작성한 점 양해 부탁드립니다.
- ControllerTest는 테스트 코드의 성공 여부를 중요시했기에 아직 상속받아 사용하지 않았고, 추후에 상속받아 사용할 예정입니다.
### ❓ 리뷰 포인트
- 테스트 함수 명, 변수 명, 변수의 값과 사용한 문법이 적절한지 판단해주시면 감사하겠습니다!
### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
