### PR TITLE
모집 게시물 리스트 API 리팩토링

### DIFF
--- a/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentBoardNoOffsetResponse.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentBoardNoOffsetResponse.java
@@ -34,7 +34,20 @@ public class RecruitmentBoardNoOffsetResponse {
                 .build();
     }
 
-    public static RecruitmentBoardNoOffsetResponse from(int pageSize, List<RecruitmentBoard> recruitmentBoardList) {
+    public static RecruitmentBoardNoOffsetResponse fromBoardInfo(int pageSize, List<RecruitmentBoardSummaryInfo> recruitmentBoardSummaryInfoList) {
+        boolean nextPage = false;
+        if (recruitmentBoardSummaryInfoList.size() > pageSize) {
+            nextPage = true;
+            recruitmentBoardSummaryInfoList.remove(pageSize);
+        }
+        return RecruitmentBoardNoOffsetResponse.builder()
+                .nextPage(nextPage)
+                .pageSize(pageSize)
+                .boardInfo(recruitmentBoardSummaryInfoList)
+                .build();
+    }
+
+    public static RecruitmentBoardNoOffsetResponse fromDraft(int pageSize, List<RecruitmentBoard> recruitmentBoardList) {
         boolean nextPage = false;
         if (recruitmentBoardList.size() > pageSize) {
             nextPage = true;
@@ -44,7 +57,7 @@ public class RecruitmentBoardNoOffsetResponse {
                 .nextPage(nextPage)
                 .pageSize(pageSize)
                 .boardInfo(recruitmentBoardList.stream()
-                        .map(RecruitmentBoardSummaryInfo::from)
+                        .map(RecruitmentBoardSummaryInfo::fromDraft)
                         .collect(Collectors.toList()))
                 .build();
     }
@@ -54,6 +67,8 @@ public class RecruitmentBoardNoOffsetResponse {
     @Builder
     @Schema(name = "RecruitmentBoardSummaryInfo", description = "모집 게시물 요약 정보 응답")
     public static class RecruitmentBoardSummaryInfo {
+        @Schema(description = "모집 게시물 댓글 수", example = "3")
+        private Long commentCount;
         @Schema(description = "모집 게시물 id 정보", example = "4")
         private Long boardId;
         @Schema(description = "모집 게시물 제목 정보", example = "board title")
@@ -77,8 +92,9 @@ public class RecruitmentBoardNoOffsetResponse {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime recruitmentDeadline;
 
-        public static RecruitmentBoardSummaryInfo from(RecruitmentBoard recruitmentBoardEntity) {
+        public static RecruitmentBoardSummaryInfo fromDraft(RecruitmentBoard recruitmentBoardEntity) {
             return RecruitmentBoardSummaryInfo.builder()
+                    .commentCount(0L)
                     .boardId(recruitmentBoardEntity.getId())
                     .title(recruitmentBoardEntity.getTitle())
                     .summary(recruitmentBoardEntity.getSummary())
@@ -87,7 +103,23 @@ public class RecruitmentBoardNoOffsetResponse {
                     .recruitmentTarget(recruitmentBoardEntity.getRecruitmentTarget())
                     .recruitmentNum(recruitmentBoardEntity.getRecruitmentNum())
                     .currentMemberNum(recruitmentBoardEntity.getCurrentMemberNum())
-                    .recruitmentStart(recruitmentBoardEntity.getActivityStart())
+                    .recruitmentStart(recruitmentBoardEntity.getCreatedAt())
+                    .recruitmentDeadline(recruitmentBoardEntity.getRecruitmentDeadline())
+                    .build();
+        }
+
+        public static RecruitmentBoardSummaryInfo fromEntity(RecruitmentBoard recruitmentBoardEntity) {
+            return RecruitmentBoardSummaryInfo.builder()
+                    .commentCount((long) recruitmentBoardEntity.getCommentList().size())
+                    .boardId(recruitmentBoardEntity.getId())
+                    .title(recruitmentBoardEntity.getTitle())
+                    .summary(recruitmentBoardEntity.getSummary())
+                    .type(recruitmentBoardEntity.getType())
+                    .tag(recruitmentBoardEntity.getTag())
+                    .recruitmentTarget(recruitmentBoardEntity.getRecruitmentTarget())
+                    .recruitmentNum(recruitmentBoardEntity.getRecruitmentNum())
+                    .currentMemberNum(recruitmentBoardEntity.getCurrentMemberNum())
+                    .recruitmentStart(recruitmentBoardEntity.getCreatedAt())
                     .recruitmentDeadline(recruitmentBoardEntity.getRecruitmentDeadline())
                     .build();
         }

--- a/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentBoardPageNumResponse.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/domain/dto/response/RecruitmentBoardPageNumResponse.java
@@ -34,8 +34,19 @@ public class RecruitmentBoardPageNumResponse {
                 .totalPage(recruitmentBoardList.getTotalPages())
                 .pageSort(recruitmentBoardList.getSort().toString())
                 .boardInfo(recruitmentBoardList.getContent().stream()
-                        .map(RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo::from)
+                        .map(RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo::fromEntity)
                         .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static RecruitmentBoardPageNumResponse fromBoardInfo(Page<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> recruitmentBoardList) {
+
+        return RecruitmentBoardPageNumResponse.builder()
+                .pageSize(recruitmentBoardList.getSize())
+                .pageNum(recruitmentBoardList.getNumber() + 1)
+                .totalPage(recruitmentBoardList.getTotalPages())
+                .pageSort(recruitmentBoardList.getSort().toString())
+                .boardInfo(recruitmentBoardList.getContent())
                 .build();
     }
 }

--- a/src/main/java/com/example/demo/domain/recruitment_board/repository/QueryDslRecruitmentBoardRepository.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/repository/QueryDslRecruitmentBoardRepository.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.recruitment_board.repository;
 
+import com.example.demo.domain.recruitment_board.domain.dto.response.RecruitmentBoardNoOffsetResponse;
 import com.example.demo.domain.recruitment_board.domain.entity.RecruitmentBoard;
 import com.example.demo.domain.recruitment_board.domain.vo.RecruitmentBoardType;
 import org.springframework.data.domain.Page;
@@ -9,13 +10,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface QueryDslRecruitmentBoardRepository {
-    List<RecruitmentBoard> findPublishedPageByNoOffset(int size, RecruitmentBoard lastBoard, RecruitmentBoardType boardType, boolean isFirst);
+    List<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> findPublishedPageByNoOffset(int size, RecruitmentBoard lastBoard, RecruitmentBoardType boardType);
 
-    Page<RecruitmentBoard> findPublishedPageByPageNum(Pageable pageable, RecruitmentBoardType boardType);
+    Page<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> findPublishedPageByPageNum(Pageable pageable, RecruitmentBoardType boardType);
 
-    Page<RecruitmentBoard> findPublishedPageByUserIdByPageNum(Long userId, Pageable pageable, RecruitmentBoardType boardType);
+    Page<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> findPublishedPageByUserIdByPageNum(Long userId, Pageable pageable, RecruitmentBoardType boardType);
 
-    List<RecruitmentBoard> findDraftPageByUserIdByNoOffset(Long userId, int size, Long lastBoardId, boolean isFirst);
+    List<RecruitmentBoard> findDraftPageByUserIdByNoOffset(Long userId, int size, Long lastBoardId);
 
     Optional<RecruitmentBoard> findByIdByFetchingQuestionList(Long recruitmentBoardId);
 }

--- a/src/main/java/com/example/demo/domain/recruitment_board/repository/QueryDslRecruitmentBoardRepositoryImpl.java
+++ b/src/main/java/com/example/demo/domain/recruitment_board/repository/QueryDslRecruitmentBoardRepositoryImpl.java
@@ -1,11 +1,15 @@
 package com.example.demo.domain.recruitment_board.repository;
 
 import com.example.demo.domain.board.domain.dto.vo.Status;
+import com.example.demo.domain.recruitment_board.domain.dto.response.RecruitmentBoardNoOffsetResponse;
 import com.example.demo.domain.recruitment_board.domain.entity.RecruitmentBoard;
 import com.example.demo.domain.recruitment_board.domain.vo.RecruitmentBoardType;
 import com.example.demo.global.utils.QueryDslUtils;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.example.demo.domain.comment.domain.entity.QRecruitmentBoardComment.recruitmentBoardComment;
 import static com.example.demo.domain.recruitment_board.domain.entity.QRecruitmentBoard.recruitmentBoard;
 import static com.example.demo.domain.recruitment_board.domain.entity.QRecruitmentFormAnswer.recruitmentFormAnswer;
 import static com.example.demo.domain.recruitment_board.domain.entity.QRecruitmentFormQuestion.recruitmentFormQuestion;
@@ -29,53 +34,52 @@ public class QueryDslRecruitmentBoardRepositoryImpl implements QueryDslRecruitme
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<RecruitmentBoard> findPublishedPageByNoOffset(int size, RecruitmentBoard lastBoard, RecruitmentBoardType boardType, boolean isFirst) {
+    public List<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> findPublishedPageByNoOffset(int size, RecruitmentBoard lastBoard, RecruitmentBoardType boardType) {
         // TODO : 차단 유저 ID에 해당하는 게시물은 가져오지 않게 수정
-        // 처음 페이지는 lastBoardId 이하 게시물을 가져온다.
-        // 처음이 아닌 페이지는 lastBoardId 미만 게시물을 가져온다.
-        if (isFirst) {
-            return jpaQueryFactory
-                    .selectFrom(recruitmentBoard)
-                    .join(recruitmentBoard.user, user).fetchJoin()
-                    .where(recruitmentBoard.recruitmentDeadline.goe(LocalDateTime.now()),
-                            recruitmentBoard.recruitmentDeadline.goe(lastBoard.getRecruitmentDeadline()),
-                            recruitmentBoard.type.eq(boardType),
-                            recruitmentBoard.status.eq(Status.PUBLISHED))
+        // lastBoard보다 마감일이 늦는 게시물을 가져온다.
+        return jpaQueryFactory
+                .select(Projections.constructor(RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo.class,
+                        recruitmentBoardComment.count(),
+                        recruitmentBoard.id, recruitmentBoard.title,
+                        recruitmentBoard.summary, recruitmentBoard.type,
+                        recruitmentBoard.tag, recruitmentBoard.recruitmentTarget,
+                        recruitmentBoard.recruitmentNum, recruitmentBoard.currentMemberNum,
+                        recruitmentBoard.createdAt, recruitmentBoard.recruitmentDeadline))
+                .from(recruitmentBoard)
+//                .join(recruitmentBoard.user, user)
+                .leftJoin(recruitmentBoard.commentList, recruitmentBoardComment)
+                .where(getBasicWhereCondition(boardType, Status.PUBLISHED, true)
+                        .and(lastBoard == null ? Expressions.TRUE :
+                                (recruitmentBoard.recruitmentDeadline.eq(lastBoard.getRecruitmentDeadline())
+                                        .and(recruitmentBoard.id.gt(lastBoard.getId())))
+                                        .or(recruitmentBoard.recruitmentDeadline.gt(lastBoard.getRecruitmentDeadline()))
+                        )
+                )
 //                .where(recruitment.user.id.ne(userId))
-                    .orderBy(recruitmentBoard.recruitmentDeadline.asc(), recruitmentBoard.id.asc())
-                    .limit(size + 1)
-                    .fetch();
-        } else {
-            return jpaQueryFactory
-                    .selectFrom(recruitmentBoard)
-                    .join(recruitmentBoard.user, user).fetchJoin()
-                    .where(recruitmentBoard.recruitmentDeadline.goe(LocalDateTime.now())
-                            .and(recruitmentBoard.type.eq(boardType))
-                            .and(recruitmentBoard.status.eq(Status.PUBLISHED))
-                            .and(
-                                    recruitmentBoard.recruitmentDeadline.eq(lastBoard.getRecruitmentDeadline())
-                                            .and(recruitmentBoard.id.gt(lastBoard.getId()))
-                                            .or(recruitmentBoard.recruitmentDeadline.gt(lastBoard.getRecruitmentDeadline()))
-                            )
-                    )
-//                .where(recruitment.user.id.ne(userId))
-                    .orderBy(recruitmentBoard.recruitmentDeadline.asc(), recruitmentBoard.id.asc())
-                    .limit(size + 1)
-                    .fetch();
-        }
-
+                .groupBy(recruitmentBoard.id)
+                .orderBy(recruitmentBoard.recruitmentDeadline.asc(), recruitmentBoard.id.asc())
+                .limit(size + 1)
+                .fetch();
     }
 
     @Override
-    public Page<RecruitmentBoard> findPublishedPageByPageNum(Pageable pageable, RecruitmentBoardType boardType) {
+    public Page<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> findPublishedPageByPageNum(Pageable pageable, RecruitmentBoardType boardType) {
         List<OrderSpecifier> ORDERS = getAllOrderSpecifiers(pageable);
 
-        List<RecruitmentBoard> content = jpaQueryFactory
-                .selectFrom(recruitmentBoard)
-                .join(recruitmentBoard.user, user).fetchJoin()
-                .where(recruitmentBoard.type.eq(boardType),
-                        recruitmentBoard.status.eq(Status.PUBLISHED),
-                        recruitmentBoard.recruitmentDeadline.goe(LocalDateTime.now()))
+        BooleanBuilder whereCondition = getBasicWhereCondition(boardType, Status.PUBLISHED, true);
+
+        List<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> content = jpaQueryFactory
+                .select(Projections.constructor(RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo.class,
+                        recruitmentBoardComment.count(),
+                        recruitmentBoard.id, recruitmentBoard.title,
+                        recruitmentBoard.summary, recruitmentBoard.type,
+                        recruitmentBoard.tag, recruitmentBoard.recruitmentTarget,
+                        recruitmentBoard.recruitmentNum, recruitmentBoard.currentMemberNum,
+                        recruitmentBoard.createdAt, recruitmentBoard.recruitmentDeadline))
+                .from(recruitmentBoard)
+                .leftJoin(recruitmentBoard.commentList, recruitmentBoardComment)
+                .where(whereCondition)
+                .groupBy(recruitmentBoard.id)
                 .orderBy(ORDERS.toArray(OrderSpecifier[]::new))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -83,24 +87,30 @@ public class QueryDslRecruitmentBoardRepositoryImpl implements QueryDslRecruitme
         Long totalCount = jpaQueryFactory
                 .select(recruitmentBoard.count())
                 .from(recruitmentBoard)
-                .where(recruitmentBoard.type.eq(boardType),
-                        recruitmentBoard.status.eq(Status.PUBLISHED),
-                        recruitmentBoard.recruitmentDeadline.goe(LocalDateTime.now()))
+                .where(whereCondition)
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, totalCount);
     }
 
     @Override
-    public Page<RecruitmentBoard> findPublishedPageByUserIdByPageNum(Long userId, Pageable pageable, RecruitmentBoardType boardType) {
+    public Page<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> findPublishedPageByUserIdByPageNum(Long userId, Pageable pageable, RecruitmentBoardType boardType) {
         List<OrderSpecifier> ORDERS = getAllOrderSpecifiers(pageable);
 
-        List<RecruitmentBoard> content = jpaQueryFactory
-                .selectFrom(recruitmentBoard)
-                .join(recruitmentBoard.user, user).fetchJoin()
-                .where(recruitmentBoard.type.eq(boardType),
-                        recruitmentBoard.status.eq(Status.PUBLISHED),
-                        recruitmentBoard.user.id.eq(userId))
+        List<RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo> content = jpaQueryFactory
+                .select(Projections.constructor(RecruitmentBoardNoOffsetResponse.RecruitmentBoardSummaryInfo.class,
+                        recruitmentBoardComment.count(),
+                        recruitmentBoard.id, recruitmentBoard.title,
+                        recruitmentBoard.summary, recruitmentBoard.type,
+                        recruitmentBoard.tag, recruitmentBoard.recruitmentTarget,
+                        recruitmentBoard.recruitmentNum, recruitmentBoard.currentMemberNum,
+                        recruitmentBoard.createdAt, recruitmentBoard.recruitmentDeadline))
+                .from(recruitmentBoard)
+                .leftJoin(recruitmentBoard.commentList, recruitmentBoardComment)
+                .join(recruitmentBoard.user, user)
+                .where(getBasicWhereCondition(boardType, Status.PUBLISHED, true)
+                        .and(recruitmentBoard.user.id.eq(userId)))
+                .groupBy(recruitmentBoard.id)
                 .orderBy(ORDERS.toArray(OrderSpecifier[]::new))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -108,41 +118,27 @@ public class QueryDslRecruitmentBoardRepositoryImpl implements QueryDslRecruitme
         Long totalCount = jpaQueryFactory
                 .select(recruitmentBoard.count())
                 .from(recruitmentBoard)
-                .where(recruitmentBoard.type.eq(boardType),
-                        recruitmentBoard.status.eq(Status.PUBLISHED),
-                        recruitmentBoard.user.id.eq(userId))
+                .where(getBasicWhereCondition(boardType, Status.PUBLISHED, true)
+                        .and(recruitmentBoard.user.id.eq(userId)))
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, totalCount);
     }
 
     @Override
-    public List<RecruitmentBoard> findDraftPageByUserIdByNoOffset(Long userId, int size, Long lastBoardId, boolean isFirst) {
+    public List<RecruitmentBoard> findDraftPageByUserIdByNoOffset(Long userId, int size, Long lastBoardId) {
         // 처음 페이지는 lastBoardId 이하 게시물을 가져온다.
         // 처음이 아닌 페이지는 lastBoardId 미만 게시물을 가져온다.
-        if (isFirst) {
-            return jpaQueryFactory
-                    .selectFrom(recruitmentBoard)
-                    .join(recruitmentBoard.user, user).fetchJoin()
-                    .where(recruitmentBoard.id.loe(lastBoardId),
-                            recruitmentBoard.status.eq(Status.DRAFT),
-                            recruitmentBoard.user.id.eq(userId))
-                    .orderBy(recruitmentBoard.createdAt.desc())
-                    // nextPage 여부를 판단하기 위해 + 1
-                    .limit(size + 1)
-                    .fetch();
-        } else {
-            return jpaQueryFactory
-                    .selectFrom(recruitmentBoard)
-                    .join(recruitmentBoard.user, user).fetchJoin()
-                    .where(recruitmentBoard.id.lt(lastBoardId),
-                            recruitmentBoard.status.eq(Status.DRAFT),
-                            recruitmentBoard.user.id.eq(userId))
-                    .orderBy(recruitmentBoard.createdAt.desc())
-                    // nextPage 여부를 판단하기 위해 + 1
-                    .limit(size + 1)
-                    .fetch();
-        }
+        return jpaQueryFactory
+                .selectFrom(recruitmentBoard)
+                .join(recruitmentBoard.user, user)
+                .where(recruitmentBoard.status.eq(Status.DRAFT)
+                        .and(recruitmentBoard.user.id.eq(userId))
+                        .and(lastBoardId == null ? Expressions.TRUE : recruitmentBoard.id.lt(lastBoardId)))
+                .orderBy(recruitmentBoard.createdAt.desc())
+                // nextPage 여부를 판단하기 위해 + 1
+                .limit(size + 1)
+                .fetch();
     }
 
     @Override
@@ -165,6 +161,16 @@ public class QueryDslRecruitmentBoardRepositoryImpl implements QueryDslRecruitme
                 .fetch();
 
         return Optional.of(result);
+    }
+
+    public BooleanBuilder getBasicWhereCondition(RecruitmentBoardType boardType, Status status, boolean shouldActive) {
+        BooleanBuilder whereCondition = new BooleanBuilder();
+        whereCondition.and(recruitmentBoard.type.eq(boardType));
+        whereCondition.and(recruitmentBoard.status.eq(status));
+        if (shouldActive) {
+            whereCondition.and(recruitmentBoard.recruitmentDeadline.goe(LocalDateTime.now()));
+        }
+        return whereCondition;
     }
 
     private List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable) {


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
1. Offset, No-Offset 페이징 API Response Dto에 게시물 댓글 개수 추가
2. No-Offset 페이징 요청에서 가장 처음 요청 시 처리 방식 변경
  - No-Offset 페이징은 이전 페이징의 결과에서 가장 마지막에 반환된 게시물 Id를 기준으로 다음 페이징을 가져오는 방식임
    - 가장 처음 요청 시 가장 마지막에 반환된 게시물 Id가 존재하지 않으므로 null을 받게됨
    - 처음 요청이 아닌 경우 가장 마지막에 반환된 게시물과 비교하여 특정 조건을 만족하는 레코드만 필터링 한 후, limit 연산자를 통해 특정 개수만 반환되게 한다.
  - 기존 처리 방식 : 가장 처음 조회되는 게시물 Id를 찾고, 찾은 게시물 Id를 가지고 페이징을 진행(쿼리를 2번 날리는 방식)
  - 개선한 처리 방식 : where 절에 lastBoardId가 null이면 lastBoardId 기준으로 레코드를 필터링 하지 않고, 항상 참이 되도록 변경 -> 모든 모집 게시물을 가져온 후 limit 연산자를 통해 특정 개수만 반환되게 한다.
### ❓ 리뷰 포인트
1. QueryDsl 구현체에서 댓글 count를 가져오는 방식 및 where 절 변경된 부분만 확인해주시면 됩니다!
2. Flyway를 PR에 올릴까 고민을 했는데, 해당 부분은 멀티모듈로 변경 시에 분리가 되어야하는 내용이므로, 프로젝트 멀티모듈화가 완료된 후 모듈로 만들어진 Flyway Application을 붙이는 것이 좋겠다고 생각하여 추후 올리도록 하겠습니다.
### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
