### PR TITLE
OAuth2UserInfo에서 사용되지 않는 필드 삭제

### DIFF
--- a/src/main/java/com/example/demo/global/oauth/user/AbstractOAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/global/oauth/user/AbstractOAuth2UserInfo.java
@@ -6,9 +6,6 @@ public abstract class AbstractOAuth2UserInfo implements OAuth2UserInfo{
 	protected Map<String, Object> attributes;
 	protected String accessToken;
 	protected String id;
-	protected String email;
-	protected String nickName;
-	protected String profileImageUrl;
 
 	protected abstract void AbstractOAuth2UserInfo(String accessToken, Map<String, Object> attributes);
 
@@ -25,20 +22,5 @@ public abstract class AbstractOAuth2UserInfo implements OAuth2UserInfo{
 	@Override
 	public String getId() {
 		return id;
-	}
-
-	@Override
-	public String getEmail() {
-		return email;
-	}
-
-	@Override
-	public String getNickname() {
-		return nickName;
-	}
-
-	@Override
-	public String getProfileImageUrl() {
-		return profileImageUrl;
 	}
 }

--- a/src/main/java/com/example/demo/global/oauth/user/OAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/global/oauth/user/OAuth2UserInfo.java
@@ -11,10 +11,4 @@ public interface OAuth2UserInfo {
 	Map<String, Object> getAttributes();
 
 	String getId();
-
-	String getEmail();
-
-	String getNickname();
-
-	String getProfileImageUrl();
 }

--- a/src/main/java/com/example/demo/global/oauth/user/github/GithubOAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/global/oauth/user/github/GithubOAuth2UserInfo.java
@@ -15,9 +15,6 @@ public class GithubOAuth2UserInfo extends AbstractOAuth2UserInfo {
 	protected void AbstractOAuth2UserInfo(String accessToken, Map<String, Object> attributes) {
 		this.accessToken = accessToken;
 		this.id = String.valueOf(attributes.get("id"));
-		this.email = (String) attributes.get("email");
-		this.nickName = (String) attributes.get("login");
-		this.profileImageUrl = (String) attributes.get("avatar_url");
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/global/oauth/user/google/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/global/oauth/user/google/GoogleOAuth2UserInfo.java
@@ -14,9 +14,6 @@ public class GoogleOAuth2UserInfo extends AbstractOAuth2UserInfo {
 		this.accessToken = accessToken;
 		this.attributes = attributes;
 		this.id = (String) attributes.get("sub");
-		this.email = (String) attributes.get("email");
-		this.nickName = null;
-		this.profileImageUrl = (String) attributes.get("picture");
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/global/oauth/user/kakao/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/global/oauth/user/kakao/KakaoOAuth2UserInfo.java
@@ -20,12 +20,8 @@ public class KakaoOAuth2UserInfo extends AbstractOAuth2UserInfo {
 		this.attributes = kakaoProfile;
 
 		this.id = ((Long) attributes.get("id")).toString();
-		this.email = (String) kakaoAccount.get("email");
-		this.nickName = (String) attributes.get("nickname");
-		this.profileImageUrl = (String) attributes.get("profile_image_url");
 
 		this.attributes.put("id", id);
-		this.attributes.put("email", this.email);
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/global/oauth/user/naver/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/global/oauth/user/naver/NaverOAuth2UserInfo.java
@@ -17,9 +17,6 @@ public class NaverOAuth2UserInfo extends AbstractOAuth2UserInfo {
 		// attributes 맵의 response 키의 값에 실제 attributes 맵이 할당되어 있음
 		this.attributes = (Map<String, Object>) attributes.get("response");
 		this.id = (String) this.attributes.get("id");
-		this.email = (String) this.attributes.get("email");
-		this.nickName = (String) attributes.get("nickname");
-		this.profileImageUrl = (String) attributes.get("profile_image");
 	}
 
 	@Override


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- OAuth2UserInfo에서 불필요한 이메일, 닉네임, 프로필 사진 필드 및 메서드를 삭제했습니다.
- Spring Security OAuth 2 설정에서 리다이렉트 URL이 https로 설정되도록 했으며 이를 동기화합니다.
### ❓ 리뷰 포인트
<!-- ex) query가 너무 많이 나가는 것 같아요 -->
<!-- ex) service 로직 너무 뚱뚱해요 -->
<!-- ex) 테스트 어떤가요. -->
- 잘못 삭제된 부분이 있는지 확인 부탁드립니다.
### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
