### PR TITLE
kakao_account을 반환하지 않아 발생하는 null 오류 수정

### DIFF
--- a/src/main/java/com/example/demo/global/oauth/user/kakao/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/global/oauth/user/kakao/KakaoOAuth2UserInfo.java
@@ -14,14 +14,7 @@ public class KakaoOAuth2UserInfo extends AbstractOAuth2UserInfo {
 	@Override
 	protected void AbstractOAuth2UserInfo(String accessToken, Map<String, Object> attributes) {
 		this.accessToken = accessToken;
-		// attributes 맵의 kakao_account 키의 값에 실제 attributes 맵이 할당되어 있음
-		Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-		Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
-		this.attributes = kakaoProfile;
-
 		this.id = ((Long) attributes.get("id")).toString();
-
-		this.attributes.put("id", id);
 	}
 
 	@Override


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 카카오 계정에서 불필요한 개인정보 수집을 하지 않도록 설정한 후 #135 를 머지했습니다.
- 이에 따라 카카오 계정 정보를 카카오 API에서 반환하지 않았으며 이 PR에서 null 오류가 발생하는 점을 수정합니다.
### ❓ 리뷰 포인트
<!-- ex) query가 너무 많이 나가는 것 같아요 -->
<!-- ex) service 로직 너무 뚱뚱해요 -->
<!-- ex) 테스트 어떤가요. -->
### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
