### PR TITLE
세미나/공지사항 게시물 삭제시 좋아요 일괄  soft 삭제 구현 추가 및 board content 데이터 타입 변경  

### DIFF
--- a/src/main/java/com/example/demo/domain/board/service/implement/LikeHandler.java
+++ b/src/main/java/com/example/demo/domain/board/service/implement/LikeHandler.java
@@ -45,4 +45,8 @@ public class LikeHandler {
             throw new ServiceException(ErrorCode.USER_NOT_LIKE_BOARD);
         }
     }
+
+    public void removeAllByBoardId(Long boardId) {
+        likeRepository.deleteLikesByBoardId(boardId);
+    }
 }

--- a/src/main/java/com/example/demo/domain/board/service/repository/LikeRepository.java
+++ b/src/main/java/com/example/demo/domain/board/service/repository/LikeRepository.java
@@ -13,4 +13,6 @@ public interface LikeRepository {
 	void deleteLike(Long userId, Long boardId);
 
 	Page<BoardTitleInfo> findLikedBoardPageByUserId(Long userId, Pageable pageable);
+
+	void deleteLikesByBoardId(Long boardId);
 }

--- a/src/main/java/com/example/demo/domain/board/service/service/BoardService.java
+++ b/src/main/java/com/example/demo/domain/board/service/service/BoardService.java
@@ -17,6 +17,7 @@ import com.example.demo.domain.board.service.implement.BoardCategoryWriter;
 import com.example.demo.domain.board.service.implement.BoardReader;
 import com.example.demo.domain.board.service.implement.BoardValidator;
 import com.example.demo.domain.board.service.implement.BoardWriter;
+import com.example.demo.domain.board.service.implement.LikeHandler;
 import com.example.demo.domain.board.service.view.implement.ViewCounter;
 import com.example.demo.domain.newsletter.event.EmailNotificationEvent;
 import com.example.demo.domain.newsletter.strategy.SeminarSummaryEmailDeliveryStrategy;
@@ -44,8 +45,7 @@ public class BoardService {
     private final UserReader userReader;
     private final BoardCategoryWriter boardCategoryWriter;
     private final BoardValidator boardValidator;
-
-
+    private final LikeHandler likeHandler;
 
     @Transactional
     public BoardInfo saveDraftBoard(Long userId, BoardContent boardContent, BoardCategoryNames boardCategoryNames) {
@@ -107,6 +107,7 @@ public class BoardService {
                 .orElseThrow(() -> new ServiceException(ErrorCode.BOARD_NOT_FOUND));
         boardValidator.validateUserEqualBoardUser(userId, savedBoardInfo);
 
+        likeHandler.removeAllByBoardId(boardId);
         boardCategoryWriter.removeBoardCategories(savedBoardInfo);
         boardWriter.removeBoardContent(savedBoardInfo);
     }

--- a/src/main/java/com/example/demo/infra/board/entity/Board.java
+++ b/src/main/java/com/example/demo/infra/board/entity/Board.java
@@ -42,7 +42,7 @@ public class Board extends BaseEntity implements CommentBoard {
     private String title;
 
     @Lob
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT",nullable = false)
     @NotBlank(message = "본문은 빈 값일 수 없습니다.")
     private String content;
 

--- a/src/main/java/com/example/demo/infra/board/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/infra/board/repository/LikeRepositoryImpl.java
@@ -80,6 +80,17 @@ public class LikeRepositoryImpl implements LikeRepository {
 	}
 
 	@Transactional
+	@Override
+	public void deleteLikesByBoardId(Long boardId) {
+		QLike like = QLike.like;
+		queryFactory
+			.update(like)
+			.set(like.deletedAt,LocalDateTime.now())
+			.where(like.board.id.eq(boardId))
+			.execute();
+	}
+
+	@Transactional
 	public void deleteByUserIdAndBoardId(Long userId, Long boardId) {
 		QLike like = QLike.like;
 		queryFactory


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 

- 게시물 삭제시 좋아요 일괄  soft 삭제 구현 추가
- board content 데이터 타입 변경  (기존 데이터 타입 TinyText -> Text) 

### ❓ 리뷰 포인트

### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
