### PR TITLE
탈퇴한 사용자의 닉네임으로 가입할 수 있도록 수정

### DIFF
--- a/src/main/java/com/example/demo/domain/user/service/UserAdminService.java
+++ b/src/main/java/com/example/demo/domain/user/service/UserAdminService.java
@@ -43,6 +43,7 @@ public class UserAdminService {
 
     @Transactional
     public void deleteUser(Long userId) {
+        userWriter.updateNickName(userId, userId + "_deleted_" + userReader.getUserInfo(userId).getNickname());
         userWriter.deleteUser(userId);
     }
 }

--- a/src/main/java/com/example/demo/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/demo/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -141,6 +141,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         userJpaRepository.findByProviderAndProviderId(provider, principal.getUserInfo().getId())
                 .ifPresent(user -> {
+                    user.updateNickname(user.getId() + "_deleted_" + user.getNickname());
                     userJpaRepository.delete(user);
                     refreshTokenCrudRepository.deleteById(user.getId());
                 });


### PR DESCRIPTION
### 🌱 작업 사항 
- 탈퇴한 사용자의 닉네임으로 가입이 불가능한 오류를 수정했습니다.
- 탈퇴한 사용자의 닉네임을 `{userId} + "_deleted_" + {탈퇴한 사용자의 닉네임}`으로 수정 후 논리 삭제를 진행합니다.
### ❓ 리뷰 포인트
- 쿼리가 상당히 많이 날라가는데 회원탈퇴가 많아진다면? 성능에 문제가 생길거라고 생각합니다. 어떻게 생각하시는지 궁금합니다.
### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
