### PR TITLE
[#156] 뉴스레터 로깅 추가 및 디스코드 메시지 수정

### DIFF
--- a/src/main/java/com/example/demo/domain/newsletter/service/EmailService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/EmailService.java
@@ -31,21 +31,27 @@ public class EmailService {
 
     @Async
     public void sendEmailNotice(List<String> subscriberEmails, EmailDeliveryStrategy emailStrategy) {
-        log.info("이메일 전송을 시작합니다. 구독자 이메일 목록: {}", subscriberEmails);
+        log.info("이메일 전송을 시작합니다. 이메일 제목: {}, 구독자 이메일 목록({}명): {}", emailStrategy.getSubject(), subscriberEmails.size(), subscriberEmails);
 
+        int failed = 0;
         for (String email : subscriberEmails) {
             try {
                 MimeMessage mimeMessage = createMimeMessage(email, emailStrategy);
                 javaMailSender.send(mimeMessage);
-                log.info("이메일 전송에 성공했습니다. 이메일: {}", email);
+                log.debug("이메일 전송에 성공했습니다. 이메일: {}, 이메일 제목: {}", email, emailStrategy.getSubject());
             } catch (AddressException e) {
-                log.error("유효하지 않은 이메일 주소입니다. 이메일: {}, 오류 메시지: {}", email, e.getMessage());
+                log.warn("유효하지 않은 이메일 주소입니다. 이메일: {}, 오류 메시지: {}, 이메일 제목: {}", email, e.getMessage(), emailStrategy.getSubject());
+                ++failed;
             } catch (MessagingException e) {
-                log.error("이메일 전송 중 오류 발생. 이메일: {}, 오류 메시지: {}", email, e.getMessage());
+                log.warn("이메일 전송 중 오류가 발생했습니다. 이메일: {}, 오류 메시지: {}, 이메일 제목: {}", email, e.getMessage(), emailStrategy.getSubject());
+                ++failed;
             } catch (Exception e) {
-                log.error("예상치 못한 오류 발생. 이메일: {}, 오류 메시지: {}", email, e.getMessage());
+                log.error("이메일 전송 중 예상치 못한 오류가 발생했습니다. 이메일: {}, 오류 메시지: {}, 이메일 제목: {}", email, e.getMessage(), emailStrategy.getSubject());
+                ++failed;
             } // 오류가 나는 이메일에 대해 로그만 찍고, 다른 모든 메일에 대해 전송 시도
         }
+
+        log.info("이메일 전송을 완료했습니다. 이메일 제목: {}, 총 {}명 중 {}명 성공, {}명 실패", emailStrategy.getSubject(), subscriberEmails.size(), subscriberEmails.size() - failed, failed);
         sendDiscordNotification(emailStrategy); // 모든 이메일 전송이 끝나면 디스코드로 알림
     }
 

--- a/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
@@ -29,14 +29,14 @@ public class NewsletterService {
     public void updateNewsletterNotify(NewsletterSubscription newsletterSubscription) {
         validateNewsletterSubscriptionExists(newsletterSubscription.getEmail());
         newsletterHandler.updateNewsletterSubscription(newsletterSubscription);
-        log.info("뉴스레더 구독 정보가 갱신되었습니다. 구독자 이메일: {}", newsletterSubscription.getEmail());
+        log.info("뉴스레터 구독 정보가 갱신되었습니다. 구독자 이메일: {}", newsletterSubscription.getEmail());
     }
 
     @Transactional
     public void deleteNewsletterInfo(String email) {
         validateNewsletterSubscriptionExists(email);
         newsletterHandler.deleteNewsletterSubscription(email);
-        log.info("뉴스레더 구독이 취소되었습니다. 구독자 이메일: {}", email);
+        log.info("뉴스레터 구독이 취소되었습니다. 구독자 이메일: {}", email);
     }
 
     private void validateNewsletterSubscriptionNotExists(String email) {

--- a/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/example/demo/domain/newsletter/service/NewsletterService.java
@@ -4,12 +4,14 @@ import com.example.demo.domain.newsletter.entity.NewsletterSubscription;
 import com.example.demo.domain.newsletter.implement.NewsletterHandler;
 import com.example.demo.global.base.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.demo.global.base.exception.ErrorCode.SUBSCRIBE_EMAIL_CONFLICT;
 import static com.example.demo.global.base.exception.ErrorCode.SUBSCRIBE_NOT_FOUND;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -20,32 +22,21 @@ public class NewsletterService {
     public void subscribe(NewsletterSubscription newsletterSubscription) {
         validateNewsletterSubscriptionNotExists(newsletterSubscription.getEmail());
         newsletterHandler.saveNewsletterSubscription(newsletterSubscription);
+        log.info("뉴스레터 구독이 완료되었습니다. 구독자 이메일: {}", newsletterSubscription.getEmail());
     }
 
-//    public NewsletterInfo getNewsletterInfo(Long userId) {
-//        User user = userService.validateUser(userId);
-//        if (!user.hasNewsletter()) {
-//            throw new ServiceException(SUBSCRIBE_NOT_FOUND);
-//        }
-//        return NewsletterInfo.from(user.getNewsletter());
-//    }
-
-//    @Transactional
-//    public void updateNewsletterEmail(NewsletterUpdateEmailRequest request) {
-//        this.validateSubscribe(request.email());
-//        Newsletter newsletter = newsletterRepository.findByEmail(request.email())
-//                .orElseThrow(() -> new ServiceException(SUBSCRIBE_NOT_FOUND));
-//        newsletter.updateNewsletter(request);
-//    }
-
+    @Transactional
     public void updateNewsletterNotify(NewsletterSubscription newsletterSubscription) {
         validateNewsletterSubscriptionExists(newsletterSubscription.getEmail());
         newsletterHandler.updateNewsletterSubscription(newsletterSubscription);
+        log.info("뉴스레더 구독 정보가 갱신되었습니다. 구독자 이메일: {}", newsletterSubscription.getEmail());
     }
 
+    @Transactional
     public void deleteNewsletterInfo(String email) {
         validateNewsletterSubscriptionExists(email);
         newsletterHandler.deleteNewsletterSubscription(email);
+        log.info("뉴스레더 구독이 취소되었습니다. 구독자 이메일: {}", email);
     }
 
     private void validateNewsletterSubscriptionNotExists(String email) {

--- a/src/main/java/com/example/demo/domain/newsletter/strategy/SeminarSummaryEmailDeliveryStrategy.java
+++ b/src/main/java/com/example/demo/domain/newsletter/strategy/SeminarSummaryEmailDeliveryStrategy.java
@@ -46,7 +46,7 @@ public class SeminarSummaryEmailDeliveryStrategy extends BaseEmailDeliveryStrate
         return new SeminarSummaryEmailDeliveryStrategy(
                 boardInfo.getBoardContent().getTitle(),
                 boardInfo.getUserTarget().getNickName(),
-                "https://kumoh-talk.com/apply/" + boardInfo.getBoardId() // TODO. 프론트 배포 후 수정 필요
+                "https://kumoh-talk.com/seminar/" + boardInfo.getBoardId()
         );
     }
 }

--- a/src/main/java/com/example/demo/domain/report/client/DiscordMessage.java
+++ b/src/main/java/com/example/demo/domain/report/client/DiscordMessage.java
@@ -68,11 +68,11 @@ public class DiscordMessage {
                                                         + "### 🎈 알림 주제\n"
                                                         + emailDeliveryStrategy.getSubject()
                                                         + (!(emailDeliveryStrategy instanceof ByPassEmailDeliveryStrategy)
-                                                        ? "### 📄 알림 내용\n"
+                                                        ? "\n### 📄 알림 내용\n"
                                                         + "```json\n"
                                                         + "게시물 제목 : " + emailDeliveryStrategy.getVariables().get("title") + ",\n"
                                                         + "게시물 작성자 : " + emailDeliveryStrategy.getVariables().get("author") + ",\n"
-                                                        + "게시물 URL : " + emailDeliveryStrategy.getVariables().get("postUrl") + ",\n"
+                                                        + "게시물 URL : " + emailDeliveryStrategy.getVariables().get("postUrl")
                                                         + "\n```" : "\n"))
                                         .build()
                         )

--- a/src/main/java/com/example/demo/domain/report/client/DiscordMessage.java
+++ b/src/main/java/com/example/demo/domain/report/client/DiscordMessage.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.report.client;
 
 import com.example.demo.domain.comment.entity.CommentInfo;
+import com.example.demo.domain.newsletter.strategy.ByPassEmailDeliveryStrategy;
 import com.example.demo.domain.newsletter.strategy.EmailDeliveryStrategy;
 import com.example.demo.domain.user.entity.UserTarget;
 import lombok.*;
@@ -66,7 +67,13 @@ public class DiscordMessage {
                                                         + "\n"
                                                         + "### 🎈 알림 주제\n"
                                                         + emailDeliveryStrategy.getSubject()
-                                                        + "\n")
+                                                        + (!(emailDeliveryStrategy instanceof ByPassEmailDeliveryStrategy)
+                                                        ? "### 📄 알림 내용\n"
+                                                        + "```json\n"
+                                                        + "게시물 제목 : " + emailDeliveryStrategy.getVariables().get("title") + ",\n"
+                                                        + "게시물 작성자 : " + emailDeliveryStrategy.getVariables().get("author") + ",\n"
+                                                        + "게시물 URL : " + emailDeliveryStrategy.getVariables().get("postUrl") + ",\n"
+                                                        + "\n```" : "\n"))
                                         .build()
                         )
                 )

--- a/src/test/java/com/example/demo/migration/FlywayMigrationTest.java
+++ b/src/test/java/com/example/demo/migration/FlywayMigrationTest.java
@@ -17,7 +17,7 @@ class FlywayMigrationTest {
 
     @Test
     void testMigration() {
-        MySQLContainer<?> mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:latest"))
+        MySQLContainer<?> mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.4"))
                 .withUsername("test")
                 .withPassword("test")
                 .withDatabaseName("testdb");


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
**NewsletterService**
- 뉴스레터 구독자 등록, 수정, 취소에 성공하면 INFO 레벨 로그를 출력합니다.

**EmailService**
- 뉴스레터 발송 시작 시 구독자 목록을 INFO 레벨 로그로 출력합니다.
- 구독자별 뉴스레터 발송 성공 여부를 DEBUG 레벨 로그로 출력하도록 조정합니다. 구독자마다 성공 여부를 출력하는 것이 너무 많은 로그를 쌓는다고 생각했습니다.
- 구독자별 뉴스레터 발송 실패 중 AddressException, MessagingException 예외 발생 시 WARN 레벨 로그로 출력하도록 조정합니다. 외부 서비스 이용 중 발생하는 오류라 애플리케이션에서 처리할 수 없다고 생각해서 ERROR 레벨에서 WARN 레벨로 조정했습니다.
- 이외이 뉴스레터 발송 실패는 ERROR 레벨로 로그를 출력합니다.

**SeminarSummaryEmailDeliveryStrategy**
- 세미나 요약 게시물 등록 뉴스레터의 URL을 수정합니다.

**DiscordMessage**
- 뉴스레터 발송 이후 전송되는 디스코드 메시지를 더 자세하게 출력합니다.
### ❓ 리뷰 포인트
- 불필요한 로깅인지 확인 부탁드립니다.
- 로그 레벨이 적절한지 확인 부탁드립니다.

### 🦄 관련 이슈
resolves #156 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Email notifications now include improved logging, providing more detailed information about the sending process and results.
  - Discord notifications for newsletters now display additional details (post title, author, and URL) when applicable.

- **Improvements**
  - Updated seminar summary emails to include direct links to the relevant seminar page.
  - Enhanced logging for newsletter subscription, update, and cancellation actions for better traceability.

- **Other**
  - Removed unused code related to newsletter info retrieval and email updates.
  - Specified a fixed MySQL Docker image version for database migration tests to ensure consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->