### PR TITLE
로그인 시 JWT Claim인 닉네임이 빈 문자열로 되는 오류 해결

### DIFF
--- a/src/main/java/com/example/demo/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/demo/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -113,7 +113,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             isNewUser.set(true);
         }
 
-        Token tokens = jwtHandler.createTokens(JwtUserClaim.create(user.getId(), "", user.getRole()));
+        String nickname = user.getRole().equals(Role.ROLE_GUEST) ? "" : user.getNickname();
+
+        Token tokens = jwtHandler.createTokens(JwtUserClaim.create(user.getId(), nickname, user.getRole()));
 
         return UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("is-new-user", isNewUser.get())


### PR DESCRIPTION
### 🌱 작업 사항 
- 로그인 시 JWT Claim인 닉네임이 빈 문자열로 되는 오류를 수정합니다.
- 로그아웃 후 로그인일 때의 경우를 테스트하지 않아 발생했습니다. 꼼꼼히 확인하겠습니다.

### ❓ 리뷰 포인트

### 🦄 관련 이슈
#158 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the assignment of user nicknames in JWT tokens during login, ensuring that only users with roles other than guest have their actual nickname included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->